### PR TITLE
fix: prime GL128 before first scan

### DIFF
--- a/docs/scanner-validation.md
+++ b/docs/scanner-validation.md
@@ -53,6 +53,42 @@ Helpers:
 | `tools/sane_debug_to_trace.py` | Convert a SANE debug log to JSON |
 | `tools/scanlab/` | PyQt6 bring-up GUI (mock or real scan-ready hardware); [user guide](../tools/scanlab/README.md) |
 
+## GL128 first-pass positioning
+
+The OpticFilm 8100 (V2) and 8200i SE use a GL128 feed sequence whose first
+image pass after opening the scanner can land at a different vertical position
+from later passes. This is a physical positioning issue, not image alignment:
+repeated 1200 dpi full-frame scans showed a roughly 46-pixel first-to-second
+pass displacement, while later passes stayed within approximately 2 pixels.
+
+The public `Scanner.scan()` path therefore performs one discarded, single-pass
+colour scan the first time a GL128 scanner is used. That pass completes the
+normal image-session shutdown, including the capture-proven `AGOHOME` return to
+home. The requested scan then runs after this priming cycle. Priming is tracked
+per `Scanner` instance and is not repeated for later scans from that instance.
+
+The priming pass deliberately disables caller progress/cancel callbacks and
+multi-exposure/infrared modes. It does not need to match the requested scan:
+the `AGOHOME` park at the end of any completed image pass establishes the same
+repeatable home regardless of PPI or area. Measured on the OpticFilm 8100 V2,
+one discarded 600 dpi pass over a small top crop (about 5 s, constant) makes
+the first retained scan land within ~1 px of the steady-state position, versus
+~30 px with no prime, whereas a full-frame prime costs about 24 s at 1200 dpi
+and scales with the requested PPI (~71 s at 3600, ~150 s at 7200). The default
+prime is therefore the small 600 dpi crop; `POF_GL128_PRIME` can override it
+(`full` for the legacy full pass at the requested PPI, or
+`<dpi>:x0,y0,x1,y1` for a custom pass).
+
+If priming fails, the requested scan is not started and the scanner remains
+unprimed for a later retry.
+
+The discarded pass adds a fixed, small constant to the first scan of a GL128
+session. A standalone reverse-home operation is not capture-proven on this
+hardware; the image-pass `AGOHOME` park is. Note that aborting an image pass
+early (start-then-cancel) is not a substitute: the `AGOHOME` park has been
+observed to time out in that case, stranding the carriage mid-window with no
+capture-proven recovery short of a power cycle.
+
 ## Current golden: OpticFilm 8200i, 1800 dpi, RGB16
 
 Phase recorded: ASIC `init()` + `ScanSession._configure()` (no home poll, no

--- a/src/pyopticfilm/scanner.py
+++ b/src/pyopticfilm/scanner.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import threading
 from collections.abc import Callable
 from pathlib import Path
@@ -26,6 +27,39 @@ from pyopticfilm.usb.fake import FakeDeviceHandle, MockScannerTransport
 from pyopticfilm.usb.protocol import GenesysUsbProtocol, UsbTransport
 
 logger = get_logger(__name__)
+
+# GL128 prime (discarded first image pass): fixed 600 dpi over a small top
+# crop for all GL128 models. Measured on the OpticFilm 8100 V2: one such pass
+# (~5 s, constant) lands the first retained scan within ~1 px @1200 of the
+# steady-state position, versus ~30 px with no prime. A full-frame prime
+# costs scale with the requested PPI (~24 s @1200, ~71 s @3600, ~150 s @7200);
+# the AGOHOME park does not.
+#
+# Override with POF_GL128_PRIME:
+#   unset/empty         -> default small pass (600 dpi, area (0, 0, 1, 0.12))
+#   full                -> full pass at the requested PPI and area
+#   <dpi>:x0,y0,x1,y1   -> custom pass, e.g. 600:0.0,0.0,1.0,0.12
+_PRIME_ENV = "POF_GL128_PRIME"
+_PRIME_DEFAULT = (600, (0.0, 0.0, 1.0, 0.12))
+
+
+def _gl128_prime_spec() -> tuple[int, tuple[float, float, float, float] | None]:
+    """(resolution, area) for the discarded GL128 prime pass.
+
+    A resolution of 0 or area of ``None`` means "use the requested values"
+    (full pass at the caller's PPI/area).
+    """
+    raw = os.environ.get(_PRIME_ENV, "").strip()
+    if not raw:
+        return _PRIME_DEFAULT
+    if raw.lower() == "full":
+        return 0, None
+    if ":" in raw:
+        dpi_part, area_part = raw.split(":", 1)
+        x0, y0, x1, y1 = (float(v) for v in area_part.split(","))
+        return int(dpi_part), (x0, y0, x1, y1)
+    raise ValueError(f"POF_GL128_PRIME must be 'full' or '<dpi>:x0,y0,x1,y1', got {raw!r}")
+
 
 ScanMode = Literal["color", "infrared", "gray"]
 
@@ -62,6 +96,9 @@ class Scanner:
         #: When True, scan/home/park are allowed even if ``scan_ready`` is False.
         #: Set only by :meth:`open_fake` (mock USB). Real hardware stays gated.
         self._allow_unvalidated_scan = False
+        #: GL128's first image pass after open establishes the repeatable AGOHOME
+        #: park position. It is discarded before the first user-visible scan.
+        self._gl128_primed = False
 
     @classmethod
     def open(
@@ -251,6 +288,42 @@ class Scanner:
             if not self._asic.is_at_home():
                 self._asic.home()
         from pyopticfilm.scan.session import create_session
+
+        run_kwargs = {
+            "resolution": resolution,
+            "mode": mode,
+            "area": area,
+            "geometry": geometry,
+            "progress": progress,
+            "cancel": cancel,
+            "apply_calib": apply_calib,
+            "multi_exposure": multi_exposure,
+            "infrared": infrared,
+            "align_passes": align_passes,
+        }
+        if getattr(self._model, "asic", "") == "GL128" and not self._gl128_primed:
+            prime_dpi, prime_area = _gl128_prime_spec()
+            if prime_area is None:
+                prime_area = area
+            if prime_dpi == 0:
+                prime_dpi = resolution
+            logger.info(
+                "GL128 priming pass (%s dpi, area=%s): discard first image to establish AGOHOME park",
+                prime_dpi,
+                prime_area,
+            )
+            prime_kwargs = {
+                **run_kwargs,
+                "resolution": prime_dpi,
+                "area": prime_area,
+                "progress": None,
+                "cancel": None,
+                "multi_exposure": False,
+                "infrared": False,
+            }
+            prime_session = create_session(self._asic, self._model, self._calibrator)
+            prime_session.run(**prime_kwargs)  # type: ignore[arg-type]
+            self._gl128_primed = True
 
         session = create_session(self._asic, self._model, self._calibrator)
         image = session.run(  # type: ignore[arg-type]

--- a/tests/test_mock_scan.py
+++ b/tests/test_mock_scan.py
@@ -82,6 +82,78 @@ def test_gl128_session_mock_scan():
     assert any(t.operation == "bulk_read" for t in usb.transactions)
 
 
+def test_gl128_scanner_primes_once_before_first_requested_scan(monkeypatch):
+    """A discarded initial pass gives GL128 its proven AGOHOME park cycle."""
+    import pyopticfilm.scan.session as session_module
+
+    scanner = Scanner.open_fake(MODEL_8200I_SE)
+    sentinel = object()
+    runs: list[dict[str, object]] = []
+
+    class FakeSession:
+        last_me_debug = None
+
+        def run(self, **kwargs):
+            runs.append(kwargs)
+            return sentinel
+
+    monkeypatch.setattr(session_module, "create_session", lambda *args: FakeSession())
+    monkeypatch.delenv("POF_GL128_PRIME", raising=False)
+    try:
+        assert scanner.scan(resolution=150, area=_TINY, apply_calib=False) is sentinel
+        assert len(runs) == 2
+        # Default prime: fixed small pass, independent of requested PPI/area.
+        assert runs[0]["resolution"] == 600
+        assert runs[0]["area"] == (0.0, 0.0, 1.0, 0.12)
+        assert runs[0]["progress"] is None
+        assert runs[0]["cancel"] is None
+        assert runs[0]["multi_exposure"] is False
+        assert runs[0]["infrared"] is False
+        assert runs[1]["resolution"] == 150
+        assert runs[1]["area"] == _TINY
+
+        assert scanner.scan(resolution=150, area=_TINY, apply_calib=False) is sentinel
+        assert len(runs) == 3
+    finally:
+        scanner.close()
+
+
+def test_gl128_prime_env_override_full_and_custom(monkeypatch):
+    """POF_GL128_PRIME selects the prime pass; 'full' keeps the requested geometry."""
+    import pyopticfilm.scan.session as session_module
+
+    def recorded_prime_kwargs() -> dict[str, object]:
+        scanner = Scanner.open_fake(MODEL_8200I_SE)  # type: ignore[arg-type]
+        runs: list[dict[str, object]] = []
+
+        class FakeSession:
+            last_me_debug = None
+
+            def run(self, **kwargs):
+                runs.append(kwargs)
+                return object()
+
+        monkeypatch.setattr(session_module, "create_session", lambda *args: FakeSession())
+        try:
+            scanner.scan(resolution=3600, area=None, apply_calib=False)
+        finally:
+            scanner.close()
+        return runs[0]
+
+    try:
+        monkeypatch.setenv("POF_GL128_PRIME", "full")
+        prime = recorded_prime_kwargs()
+        assert prime["resolution"] == 3600
+        assert prime["area"] is None
+
+        monkeypatch.setenv("POF_GL128_PRIME", "600:0.0,0.0,1.0,0.25")
+        prime = recorded_prime_kwargs()
+        assert prime["resolution"] == 600
+        assert prime["area"] == (0.0, 0.0, 1.0, 0.25)
+    finally:
+        monkeypatch.delenv("POF_GL128_PRIME", raising=False)
+
+
 def test_recording_transport_listener():
     lines: list[str] = []
 


### PR DESCRIPTION
## Summary

- Prime GL128 scanners with one **small, fixed** single-pass colour scan (600 dpi over a small top crop) before the first user-visible scan.
- Reuse the normal image-session shutdown and capture-proven `AGOHOME` park instead of adding an unproven standalone re-home sequence.
- The prime is a small, constant-cost pass (~5 s) — **not** a full-frame pass at the requested PPI.
- Add regression tests proving priming happens once per `Scanner` instance and that the prime geometry is the fixed small pass.
- Document the hardware observation and the intentional first-scan cost.

## Background

The first scan after opening a GL128 scanner starts from a displaced feed
position (approximately 30–46 px at 1200 dpi) and settles to the repeatable
`AGOHOME` park position on the second scan. The fix is mechanical: run one
discarded pass so the park position is established before the first
user-visible scan.

This is the root fix for the first-scan drift: the displacement is in the
scan positioning, not in the merge pipeline, so correcting pass alignment
cannot fix it — the first pass itself must start from the correct position.

## Why the prime is a small fixed pass

The prime does **not** need to match the requested scan. The `AGOHOME` park
that establishes the repeatable home comes from *completing any image pass*,
regardless of PPI or area. So a full-frame prime at the user's PPI wastes
most of its travel: a full-frame prime costs roughly 24 s at 1200 dpi and
scales with the requested PPI (~71 s at 3600, ~150 s at 7200), which is
exactly the high-PPI case where the added time would be most painful.

Measured on the OpticFilm 8100 V2, one discarded **600 dpi pass over a small
top crop** (~5 s, constant) keeps the first retained scan within ~1 px of the
steady-state position, versus ~30 px with no prime — identical to a full-frame
prime, for a fraction of the time.

So the default prime is the small 600 dpi crop, and it is model-agnostic
(gated only on `asic == "GL128"`). Override with `POF_GL128_PRIME`:
- unset → small 600 dpi crop `(0.0, 0.0, 1.0, 0.12)`
- `full` → legacy full-frame pass at the requested PPI/area
- `<dpi>:x0,y0,x1,y1` → custom pass

## Hardware evidence

- OpticFilm 8100 (V2), GL128, 1200 dpi, full-frame retained scans.
- No prime: first-to-second displacement ~30 px @1200 (earlier full-frame measurement ~46 px); later scans within ~2 px.
- One discarded **small 600 dpi** prime: first retained scan within ~1 px of steady state — no measurable change vs the full prime.
- A Multi-Exposure (two-pass) bracket captured before the fix shows the same first-scan displacement on the 8100 (V2), confirming the drift is in scan positioning rather than the merge path.
- A start-then-cancel prime (aborting the image pass early to skip the travel) was **not** used: the `AGOHOME` park times out when the pass is aborted and strands the carriage mid-window, with no capture-proven recovery short of a power cycle.

## Scope by hardware

- The gate is `asic == "GL128"`, so this applies to **both** GL128 models: OpticFilm 8100 (V2) and 8200i SE.
- **Hardware-validated on the 8100 (V2) so far**; the small-prime constant cost and ~1 px result were measured there, and the mechanism (first pass after `AGOHOME` park settling in the wrong feed position) is a GL128 ASIC property, not 8100-specific.
- If an 8200i SE owner reports the first scan was never misaligned, or sees a regression, `POF_GL128_PRIME=full` restores the previous behaviour and the pass can be made model-flagged in a follow-up.
