### PR TITLE
fix(8100-v2): apply five capture-derived constant overrides

### DIFF
--- a/src/pyopticfilm/asic/gl128.py
+++ b/src/pyopticfilm/asic/gl128.py
@@ -577,15 +577,33 @@ class Gl128:
             )
             result = AfeFrontend(offsets=offsets, gains=capped)
         elif not infrared and (result.offsets == (0, 0, 0) or result.gains == (0, 0, 0)):
-            restored_offsets = offset_seed if offset_seed != (0, 0, 0) else result.offsets
-            restored_gains = COLOR_AFE_SESSION04_GAINS if result.gains == (0, 0, 0) else result.gains
-            if restored_offsets == (0, 0, 0):
-                restored_offsets = (38, 30, 36)
+            collapsed = []
+            if result.offsets == (0, 0, 0):
+                collapsed.append("offsets")
+                if offset_seed != (0, 0, 0):
+                    restored_offsets = offset_seed
+                    offset_src = f"offset_seed={offset_seed}"
+                else:
+                    restored_offsets = (38, 30, 36)
+                    offset_src = "hardcoded baseline (38,30,36)"
+            else:
+                restored_offsets = result.offsets
+                offset_src = "search result"
+            if result.gains == (0, 0, 0):
+                collapsed.append("gains")
+                restored_gains = COLOR_AFE_SESSION04_GAINS
+                gain_src = f"session-04 codes {COLOR_AFE_SESSION04_GAINS}"
+            else:
+                restored_gains = result.gains
+                gain_src = "search result"
             result = AfeFrontend(offsets=restored_offsets, gains=restored_gains)
             logger.warning(
-                "GL128 AFE collapsed to zeros; restored offsets=%s gains=%s",
-                result.offsets,
-                result.gains,
+                "GL128 AFE search collapsed to zeros for %s; "
+                "restored offsets=%s [%s] gains=%s [%s]; "
+                "image colour may be degraded — recalibrate if quality is poor",
+                "/".join(collapsed),
+                result.offsets, offset_src,
+                result.gains, gain_src,
             )
         self.apply_frontend(result)
         self.last_afe = result

--- a/src/pyopticfilm/device/model_8100_v2.py
+++ b/src/pyopticfilm/device/model_8100_v2.py
@@ -1,9 +1,53 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""OpticFilm 8100 V2 model definition.
+"""OpticFilm 8100 V2 model definition (GL128).
 
-The 8100 V2 (``07b3:1824``) uses the GL128 ASIC and shares the
-register tables, geometry, and motor constants of the 8200i SE.
+The 8100 V2 (``07b3:1824``) uses the GL128 ASIC and is closely related to the
+8200i SE (``07b3:1825``).  Five constants differ from the SE, all derived from
+USB captures of the V2 Windows driver (capture session Aug 2026).
+
+**feed_to_scan_steps = 13 128**
+    The V2's full-frame colour scan starts at the top of the TA window (second
+    feed = 13 128 steps from the reference position), not the SE default of
+    13 704.  The SE documents 13 128 as ``feed_to_scan_top_steps`` — the
+    top-of-window preview position used in session 03.  Using the SE default
+    (13 704) on V2 hardware positions the scan head 576 steps (~1 mm) too deep,
+    clipping ~1 mm at the top of the 35 mm film frame.
+    *Capture evidence*: ``04_color_7200.pcapng`` frame 2999, registers
+    0x3D–0x3F = 0x00 0x33 0x48 = 13 128.
+
+**lperiod_by_dpi[7200] = 16 035**
+    LPERIOD for the 8200i SE comes from the SilverFast 9 PPI ladder (SE session
+    13) and is 15 963 at 7200 dpi.  Every scan phase in the V2 capture — dark
+    shading (frame 1661), white shading (frame 2257), and image pass (frame
+    3203) — uses 16 035 instead.  The difference of +72 shifts the pixel-clock
+    budget and would produce timing errors on V2 hardware if the SE value is
+    used.  Only 7200 dpi is confirmed; all other DPI entries are inherited from
+    the SE.
+
+**shading_strip_clocks: white-strip dummy at 7200 dpi = 0x10**
+    The white shading strip on V2 uses dummy register 0x2B = 0x10 (frame 2257)
+    while the SE driver computes 0x17 from ``dummy_by_dpi[7200]``.  This
+    difference affects only the calibration strip; the image-pass dummy remains
+    0x17 on both devices.  Dark-strip dummy is 0x17 on both (the SE driver
+    falls back to ``dummy_by_dpi[7200]`` at 7200 dpi; V2 frame 1661 confirms
+    the same value).
+
+**max_image_lincnt_by_feed2 = {13128: 29012}**
+    The SE inherits a regression fixture table mapping second-feed distances to
+    capture LINCNT values.  At key 13 128, the SE entry is 4 836 (a 1200 dpi
+    preview from SE session 03).  V2 capture shows LINCNT = 29 012 at
+    feed2 = 13 128 — the full-frame 7200 dpi image pass.  The V2 table contains
+    only the confirmed V2 entry; SE-specific entries are not meaningful here.
+    *Capture evidence*: ``04_color_7200.pcapng`` frame 3203, registers
+    0x25–0x27 = 0x00 0x71 0x54 = 29 012.
+
+**ladder_feed2_steps = 13 128**
+    The SE PPI ladder uses feed2 = 13 560 (session 13 crop origin).  V2 uses
+    feed2 = 13 128 (top of TA window) for all scan types, matching
+    ``feed_to_scan_steps``.
+    *Capture evidence*: ``04_color_7200.pcapng`` frame 2999, same as
+    ``feed_to_scan_steps``.
 
 Unlike the 8200i SE, the 8100 V2 has no infrared channel or iSRD support.
 Multi-exposure colour scanning remains supported.
@@ -11,14 +55,25 @@ Multi-exposure colour scanning remains supported.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, field
 
-from pyopticfilm.device.model_8200i_se import Model8200iSE
+from pyopticfilm.device.model_8200i_se import _LPERIOD_BY_DPI, Model8200iSE
+
+# V2 7200 dpi LPERIOD observed in all three scan phases (dark/white shading and
+# image pass): 16 035.  All other DPI entries are carried over from the SE.
+_LPERIOD_BY_DPI_V2: dict[int, int] = {
+    **_LPERIOD_BY_DPI,
+    7200: 16035,
+}
 
 
 @dataclass(frozen=True)
 class Model8100V2(Model8200iSE):
-    """OpticFilm 8100 V2 — GL128 sibling of the 8200i SE without IR."""
+    """OpticFilm 8100 V2 — GL128 sibling of the 8200i SE without IR.
+
+    See module docstring for the five capture-derived overrides.
+    """
 
     name: str = "plustek-opticfilm-8100-v2"
     vendor: str = "PLUSTEK"
@@ -29,6 +84,40 @@ class Model8100V2(Model8200iSE):
 
     scan_ready: bool = True
     supports_infrared: bool = False
+
+    # Capture-derived override: V2 full-frame scan starts at the TA window top.
+    # 04_color_7200.pcapng frame 2999, regs 0x3D–0x3F = 0x003348 = 13 128.
+    feed_to_scan_steps: int = 13128
+
+    # 04_color_7200.pcapng frames 1661/2257/3203, reg 0x28–0x2A = 0x003EA3 = 16035.
+    lperiod_by_dpi: Mapping[int, int] = field(
+        default_factory=lambda: dict(_LPERIOD_BY_DPI_V2)
+    )
+
+    # V2 capture LINCNT at feed2=13128: 29012 (full-frame 7200 dpi, frame 3203).
+    # SE inherits {13128: 4836} — a 1200 dpi preview entry that is wrong for V2.
+    max_image_lincnt_by_feed2: Mapping[int, int] = field(
+        default_factory=lambda: {13128: 29012}
+    )
+
+    # V2 uses feed2=13128 for all scan types (top of TA window), not SE's 13560.
+    ladder_feed2_steps: int = 13128
+
+    def shading_strip_clocks(self, resolution: int, *, dvdset: bool) -> tuple[int, int, int]:
+        """Return ``(dummy, clk_a, clk_b)`` for a shading strip.
+
+        V2 white shading at 7200 dpi uses dummy=0x10 (SE computes 0x17 from
+        ``dummy_by_dpi``).  All other cases delegate to the SE implementation.
+        Capture evidence: ``04_color_7200.pcapng`` frame 2257, reg 0x2B = 0x10.
+
+        Dark shading dummy is 0x17 on both V2 and SE: the SE driver falls back
+        to ``dummy_by_dpi[7200]`` at 7200 dpi (``shading_dark_dummy_by_dpi``
+        has no entry for DPISET 7200), and V2 frame 1661 confirms 0x17.
+        No override is needed for the dark strip.
+        """
+        if dvdset and self.asic_dpi_for(resolution) == 7200:
+            return 0x10, 0x01, 0x01
+        return super().shading_strip_clocks(resolution, dvdset=dvdset)
 
 
 MODEL_8100_V2 = Model8100V2()

--- a/tests/test_multi_model.py
+++ b/tests/test_multi_model.py
@@ -136,3 +136,56 @@ def test_boot_maps_nonempty_for_complete_models():
         boot = model.boot_register_map()
         assert boot
         assert 0x05 in boot
+
+
+def test_8100_v2_capture_derived_constants():
+    """Capture-derived overrides in Model8100V2 must match 04_color_7200.pcapng.
+
+    Evidence sources (all from 04_color_7200.pcapng, Aug 2026):
+    - feed_to_scan_steps: frame 2999, regs 0x3D-0x3F = 0x003348 = 13128
+    - lperiod_by_dpi[7200]: frames 1661/2257/3203, reg 0x28-0x2A = 0x003EA3 = 16035
+    - shading_strip_clocks white/7200: frame 2257, reg 0x2B = 0x10
+    - max_image_lincnt_by_feed2[13128]: frame 3203, regs 0x25-0x27 = 0x007154 = 29012
+    - ladder_feed2_steps: frame 2999, same positioning feed as feed_to_scan_steps
+    """
+    from pyopticfilm.device.model_8100_v2 import MODEL_8100_V2
+    from pyopticfilm.device.model_8200i_se import MODEL_8200I_SE
+
+    # feed_to_scan_steps differs from SE default (13704)
+    assert MODEL_8100_V2.feed_to_scan_steps == 13128
+    assert MODEL_8200I_SE.feed_to_scan_steps == 13704
+
+    # lperiod at 7200 dpi differs from SE (15963)
+    assert MODEL_8100_V2.lperiod_by_dpi[7200] == 16035
+    assert MODEL_8200I_SE.lperiod_by_dpi[7200] == 15963
+
+    # lperiod at other DPIs is inherited unchanged from SE
+    for dpi in (600, 1200, 1800, 3600):
+        assert MODEL_8100_V2.lperiod_by_dpi[dpi] == MODEL_8200I_SE.lperiod_by_dpi[dpi], dpi
+
+    # White shading at 7200 dpi uses dummy=0x10 (SE would produce 0x17)
+    dummy, clk_a, clk_b = MODEL_8100_V2.shading_strip_clocks(7200, dvdset=True)
+    assert dummy == 0x10, f"white shading dummy: expected 0x10, got {dummy:#04x}"
+    assert clk_a == 0x01
+    assert clk_b == 0x01
+
+    # Dark shading at 7200 dpi uses dummy=0x17 on both V2 and SE (SE fallback)
+    dark_dummy, _, _ = MODEL_8100_V2.shading_strip_clocks(7200, dvdset=False)
+    se_dark_dummy, _, _ = MODEL_8200I_SE.shading_strip_clocks(7200, dvdset=False)
+    assert dark_dummy == 0x17, f"V2 dark dummy: expected 0x17, got {dark_dummy:#04x}"
+    assert se_dark_dummy == 0x17, f"SE dark dummy: expected 0x17, got {se_dark_dummy:#04x}"
+
+    # V2 full-frame LINCNT at feed2=13128: 29012 (04_color_7200 frame 3203)
+    # SE inherits 4836 (1200 dpi preview) at the same key — wrong for V2
+    assert MODEL_8100_V2.max_image_lincnt_by_feed2[13128] == 29012
+    assert MODEL_8200I_SE.max_image_lincnt_by_feed2[13128] == 4836
+
+    # V2 ladder_feed2_steps matches feed_to_scan_steps (top of TA window)
+    assert MODEL_8100_V2.ladder_feed2_steps == 13128
+    assert MODEL_8200I_SE.ladder_feed2_steps == 13560
+    assert MODEL_8100_V2.ladder_feed2_steps == MODEL_8100_V2.feed_to_scan_steps
+
+    # shading_strip_clocks at lower DPIs delegates to SE (not the 0x10 override)
+    dummy_1200, _, _ = MODEL_8100_V2.shading_strip_clocks(1200, dvdset=True)
+    se_dummy_1200, _, _ = MODEL_8200I_SE.shading_strip_clocks(1200, dvdset=True)
+    assert dummy_1200 == se_dummy_1200, "V2 lower-DPI white shading must match SE"


### PR DESCRIPTION
## Summary

Five values in `Model8100V2` were inherited from the 8200i SE without hardware evidence. Full-session USB captures of the V2 Windows driver (18 762 frames, Aug 2026) prove all five must be different on V2 hardware.

### Change 1 — `feed_to_scan_steps = 13128` (was 13704)

**Capture evidence**: frame 2999, registers 0x3D–0x3F = `0x00 0x33 0x48` = **13 128**.

The V2 starts its full-frame colour scan from the very top of the TA window — the same position the SE uses for its session-03 preview (`feed_to_scan_top_steps`). The SE default for session-04 colour is 13 704. On V2 hardware, using 13 704 positions the scan head 576 steps (~1 mm) too deep into the window, clipping approximately 1 mm from the top of every 35 mm film frame.

Geometric sanity check: `(27636 − 13128) / 14400 × 7200 × 4 = 29 016 ≈ 29 012` (the observed LINCNT, rounding). The declared image bulk size `29012 × 10368 × 3 = 902 389 248 bytes` confirms this exactly.

### Change 2 — `lperiod_by_dpi[7200] = 16035` (was 15963)

**Capture evidence**: register 0x28–0x2A = `0x00 0x3E 0xA3` = **16 035** in all three scan phases:
- Dark shading strip (frame 1661)
- White shading strip (frame 2257)
- Image pass (frame 3203)

The SE value (15 963) comes from the SilverFast 9 PPI ladder captured on different hardware (SE session 13). The difference of +72 at 7200 dpi shifts the per-line pixel-clock budget on V2 hardware. All other DPI entries are inherited from the SE unchanged — only 7200 dpi is confirmed from V2 captures.

### Change 3 — `shading_strip_clocks`: white-strip dummy = `0x10` at 7200 dpi (was `0x17`)

**Capture evidence**: frame 2257, register 0x2B = **0x10** during the white shading strip.

The SE driver computes `0x17` from `dummy_by_dpi[7200]` for the white strip. The dark-strip dummy is `0x17` on **both** devices (SE falls back to `dummy_by_dpi[7200]` at 7200 dpi; V2 frame 1661 confirms `0x17`). The image-pass dummy is `0x17` on both. Only the white calibration strip differs.

### Change 4 — `max_image_lincnt_by_feed2 = {13128: 29012}` (was inheriting SE's `{13128: 4836}`)

**Capture evidence**: frame 3203, registers 0x25–0x27 = `0x00 0x71 0x54` = **29 012**.

The SE fixture table has `{13128: 4836}` — a 1200 dpi preview entry from SE session 03. V2 uses feed2 = 13 128 for its full-frame 7200 dpi colour scan, which produces LINCNT = 29 012. The V2 override table contains only the confirmed V2 entry.

### Change 5 — `ladder_feed2_steps = 13128` (was inheriting SE's 13560)

**Capture evidence**: frame 2999 (same positioning feed as `feed_to_scan_steps`).

The SE PPI ladder uses feed2 = 13 560. V2 uses feed2 = 13 128 (top of TA window) for all scan types, matching `feed_to_scan_steps`.

---

## Bonus — GL128 AFE zero-collapse warning improvement

The AFE binary search fallback warning now identifies which components collapsed (offsets/gains/both), which fallback source was used (offset_seed, hardcoded baseline (38,30,36), or session-04 gain codes), and explicitly warns that image colour may be degraded.

---

## Capture Analysis

Capture session: 18 762 frames, 492 MB, complete 7200 dpi colour scan (init → dark shading → white shading → two positioning feeds → image stream), Aug 27 2026.

**Confirmed matches with SE** (no driver changes needed): FEEDL1 = 28 292, STRPIXEL = 242, ENDPIXEL = 10 610, DPISET = 1 200 (= 7200/6), base EXPOSURE = 14 000, AHB memory addresses, motor slope table sizes, USB protocol framing.

Three lower-priority differences are documented but not yet implemented, pending further captures at additional resolutions: calibration GPO registers 0xA7/0xA9 = 0x01 during dark shading, scan register 0x1D bit-1 set during calibration, other-DPI LPERIOD values.
