### PR TITLE
feat(gl128): add manual exposure and priming-pass debug overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - **Manual exposure overrides** (GL128): `Scanner.scan(single_pass_exposure=..., me_short_exposure=..., me_long_exposure=...)` let a caller send an exact `REG_EXPOSURE` value for the retained scan/ME short/ME long pass, bypassing the adaptive selection, DPI clamp, and `me_hardware_max_exposure` clamp that apply to driver-derived exposure. `me_long_exposure` takes precedence over `me_exposure_mode`. Values are still hard-validated against the 24-bit register range (1–`0xFFFFFF`); out-of-range values raise `ValueError` rather than being clamped. All three default to `None` (unchanged behavior) and never apply to the discarded GL128 priming pass. Scan Lab exposes matching **Manual exposure overrides** fields.
+- **GL128 priming-pass override**: `Scanner.scan(gl128_prime=False)` skips the discarded first-scan AGOHOME-park pass for that call (debug/testing only — expect ~30 px of first-scan position drift). Skipping does not mark the scanner as primed, so a later call without the override still primes normally. `on_status` gains a new `"prime_skipped"` value. Defaults to `True` (unchanged behavior). Scan Lab exposes a matching **Disable priming pass (debug)** checkbox for both Prescan and Scan.
 
 ## [1.3.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Manual exposure overrides** (GL128): `Scanner.scan(single_pass_exposure=..., me_short_exposure=..., me_long_exposure=...)` let a caller send an exact `REG_EXPOSURE` value for the retained scan/ME short/ME long pass, bypassing the adaptive selection, DPI clamp, and `me_hardware_max_exposure` clamp that apply to driver-derived exposure. `me_long_exposure` takes precedence over `me_exposure_mode`. Values are still hard-validated against the 24-bit register range (1–`0xFFFFFF`); out-of-range values raise `ValueError` rather than being clamped. All three default to `None` (unchanged behavior) and never apply to the discarded GL128 priming pass. Scan Lab exposes matching **Manual exposure overrides** fields.
+
 ## [1.3.0] - 2026-08-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Other OpticFilm models **enumerate and open**: you can read status, turn the lam
 - Color and infrared transparency scans at 150–7200 dpi (ASIC programs at ≥600 dpi; lower PPI shares the 600 dpi register set and is downsampled on the host; infrared is available only on supported hardware)
 - Infrared as a dust plane on `ScanImage.ir` (`mode="infrared"`, or `infrared=True` with colour; 8200i SE only among the hardware-tested set)
 - Multi-exposure (ME) on GL128 hardware-tested models (8200i SE and 8100 V2): short + adaptive long colour passes with host SNR/IVW merge into `ScanImage.rgb` (`multi_exposure=True`); bracket planes via `Scanner.last_me_debug`
+- Manual exposure overrides on GL128 (`single_pass_exposure` / `me_short_exposure` / `me_long_exposure`) for testing/debugging: bypass the adaptive/hardware-max clamps and write an exact `REG_EXPOSURE` value (24-bit register range), never applied to the discarded priming pass
 - Optional crop via normalized `area` (`x1, y1, x2, y2` in 0–1)
 - Dark/white shading calibration with on-disk cache (`~/.cache/pyopticfilm/calib_v2.json`)
 - GL128 ASIC shading path (AFE codes + shading blob) aligned with SilverFast capture order
@@ -142,6 +143,23 @@ with Scanner.open() as scanner:
         save_rgb16_tiff(debug.rgb_long, "long.tif", dpi=image.dpi)
         print(debug.exposure_short, debug.exposure_long)  # e.g. 14000, 42000…85000
         print(debug.exposure_proposed, debug.exposure_reason)
+```
+
+Manual exposure overrides (GL128; debugging/testing only): send an exact
+``REG_EXPOSURE`` value that bypasses the adaptive selection, DPI clamp, and
+hardware-max clamp above — the value is written verbatim, limited only to the
+24-bit register range (1–``0xFFFFFF``). ``me_long_exposure`` takes precedence
+over ``me_exposure_mode``. All three default to ``None`` (unchanged behavior)
+and never apply to the discarded GL128 priming pass:
+
+```python
+image = scanner.scan(
+    resolution=1800,
+    mode="color",
+    multi_exposure=True,
+    me_short_exposure=14000,
+    me_long_exposure=120000,  # above the normal 42k–85k envelope, on purpose
+)
 ```
 
 Colour + IR in one call (8200i SE; IR after the colour / ME passes):

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Other OpticFilm models **enumerate and open**: you can read status, turn the lam
 - Infrared as a dust plane on `ScanImage.ir` (`mode="infrared"`, or `infrared=True` with colour; 8200i SE only among the hardware-tested set)
 - Multi-exposure (ME) on GL128 hardware-tested models (8200i SE and 8100 V2): short + adaptive long colour passes with host SNR/IVW merge into `ScanImage.rgb` (`multi_exposure=True`); bracket planes via `Scanner.last_me_debug`
 - Manual exposure overrides on GL128 (`single_pass_exposure` / `me_short_exposure` / `me_long_exposure`) for testing/debugging: bypass the adaptive/hardware-max clamps and write an exact `REG_EXPOSURE` value (24-bit register range), never applied to the discarded priming pass
+- Priming-pass override on GL128 (`gl128_prime=False`) for testing/debugging: skip the discarded first-scan AGOHOME-park pass for one call, without disabling it for the rest of the session
 - Optional crop via normalized `area` (`x1, y1, x2, y2` in 0–1)
 - Dark/white shading calibration with on-disk cache (`~/.cache/pyopticfilm/calib_v2.json`)
 - GL128 ASIC shading path (AFE codes + shading blob) aligned with SilverFast capture order
@@ -160,6 +161,17 @@ image = scanner.scan(
     me_short_exposure=14000,
     me_long_exposure=120000,  # above the normal 42k–85k envelope, on purpose
 )
+```
+
+Priming-pass override (GL128; debugging/testing only): GL128's first retained
+scan after open normally runs a discarded pass first (fixed 600 dpi, small
+top crop) to establish a repeatable AGOHOME park position — skipping it costs
+~30 px of first-scan position drift. `gl128_prime=False` skips that pass for
+one call without disabling it for the rest of the session: a later call
+without the override still primes normally:
+
+```python
+image = scanner.scan(resolution=1800, mode="color", gl128_prime=False)
 ```
 
 Colour + IR in one call (8200i SE; IR after the colour / ME passes):

--- a/src/pyopticfilm/scan/exposure_override.py
+++ b/src/pyopticfilm/scan/exposure_override.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Validation for explicit (manual) ``REG_EXPOSURE`` overrides.
+
+Manual overrides exist so Scan Lab / debugging can send exposure values that
+exceed the driver's normal adaptive/safety clamps (see
+:mod:`pyopticfilm.scan.me_exposure` and ``FilmModel.me_hardware_max_exposure``).
+"Unrestricted" means unrestricted with respect to those *soft* limits — the
+only hard limit is the actual register representation, so this module rejects
+values that cannot be written to the 24-bit ``REG_EXPOSURE`` register rather
+than clamping or wrapping them.
+"""
+
+from __future__ import annotations
+
+#: Largest value representable in the 24-bit REG_EXPOSURE register.
+MAX_EXPOSURE_REGISTER = 0xFFFFFF
+
+
+def validate_manual_exposure(value: int | None, *, label: str) -> int | None:
+    """Return ``value`` unchanged if it is a valid manual exposure, else raise.
+
+    ``None`` (no override requested) is always valid and preserves today's
+    behavior. Otherwise ``value`` must be a positive integer that fits
+    ``REG_EXPOSURE`` (1..0xFFFFFF) — invalid values raise ``ValueError``
+    rather than being silently clamped or wrapped.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, int):
+        raise TypeError(f"{label} must be an int or None, got {type(value).__name__}")
+    if value <= 0:
+        raise ValueError(f"{label} must be a positive integer, got {value}")
+    if value > MAX_EXPOSURE_REGISTER:
+        raise ValueError(
+            f"{label}={value} exceeds the 24-bit REG_EXPOSURE maximum "
+            f"(0x{MAX_EXPOSURE_REGISTER:06X} = {MAX_EXPOSURE_REGISTER})"
+        )
+    return value

--- a/src/pyopticfilm/scan/session.py
+++ b/src/pyopticfilm/scan/session.py
@@ -73,11 +73,19 @@ class ScanSession:
         infrared: bool = False,
         align_passes: bool = True,
         me_exposure_mode: str = "adaptive",  # GL128 ME only; ignored here
+        single_pass_exposure: int | None = None,
+        me_short_exposure: int | None = None,  # GL128 ME only; ignored here
+        me_long_exposure: int | None = None,  # GL128 ME only; ignored here
     ) -> ScanImage:
         if multi_exposure or infrared:
             raise NotImplementedError(
                 f"Multi-exposure / combined IR scans are not implemented for "
                 f"{getattr(self.model, 'asic', '?')}"
+            )
+        if single_pass_exposure is not None:
+            raise NotImplementedError(
+                "Manual exposure overrides are only implemented for GL128; "
+                f"{getattr(self.model, 'asic', '?')} does not support single_pass_exposure."
             )
         if mode == "gray":
             raise ValueError("Grayscale is experimental / not implemented yet")

--- a/src/pyopticfilm/scan/session_gl128.py
+++ b/src/pyopticfilm/scan/session_gl128.py
@@ -27,6 +27,7 @@ from pyopticfilm.device.protocol import AsicDriver, FilmModel
 from pyopticfilm.exceptions import AsicError, ScanCancelled, ScanError
 from pyopticfilm.logging import get_logger
 from pyopticfilm.scan.calibrate import Calibrator
+from pyopticfilm.scan.exposure_override import validate_manual_exposure
 from pyopticfilm.scan.geometry import ScanGeometry
 from pyopticfilm.scan.session import DATA_TIMEOUT_S, ScanSession
 from pyopticfilm.usb.device import BULK_MAX_SIZE
@@ -94,6 +95,10 @@ class Gl128ScanSession(ScanSession):
         self._pass_exposure: int | None = None
         #: Explicit ME long-pass clocks (independent of numeric exposure).
         self._pass_long_exposure: bool = False
+        #: True when ``_pass_exposure`` is a caller-supplied manual override
+        #: (Scan Lab / debug) rather than a driver-derived value — set only
+        #: for the duration of the pass that should write it verbatim.
+        self._pass_manual: bool = False
         #: Lab-only ME bracket / IVW stats (not on :class:`~pyopticfilm.image.ScanImage`).
         self.last_me_debug = None
 
@@ -104,11 +109,18 @@ class Gl128ScanSession(ScanSession):
         infrared: bool = False,
         align_passes: bool = True,
         me_exposure_mode: str = "adaptive",
+        single_pass_exposure: int | None = None,
+        me_short_exposure: int | None = None,
+        me_long_exposure: int | None = None,
         **kwargs,
     ):  # type: ignore[no-untyped-def]
         """Refuse unless the ASIC explicitly arms motor moves."""
         if not getattr(self.asic, "_motor_moves_enabled", False):
             raise AsicError(_MOTOR_GATED_HINT)
+        # Fail fast on bad manual-exposure input before any register write.
+        validate_manual_exposure(single_pass_exposure, label="single_pass_exposure")
+        validate_manual_exposure(me_short_exposure, label="me_short_exposure")
+        validate_manual_exposure(me_long_exposure, label="me_long_exposure")
         if multi_exposure or (infrared and kwargs.get("mode", "color") == "color"):
             if infrared and not getattr(self.model, "supports_infrared", False):
                 raise ScanError(
@@ -122,9 +134,20 @@ class Gl128ScanSession(ScanSession):
                 infrared=infrared,
                 align_passes=align_passes,
                 me_exposure_mode=me_exposure_mode,
+                me_short_exposure=me_short_exposure,
+                me_long_exposure=me_long_exposure,
                 **kwargs,
             )
-        return super().run(*args, **kwargs)
+        if single_pass_exposure is None:
+            # No override: identical to today's model-derived single pass.
+            return super().run(*args, **kwargs)
+        self._pass_exposure = int(single_pass_exposure)
+        self._pass_manual = True
+        try:
+            return super().run(*args, **kwargs)
+        finally:
+            self._pass_exposure = None
+            self._pass_manual = False
 
     # --- configure ------------------------------------------------------
 
@@ -207,14 +230,20 @@ class Gl128ScanSession(ScanSession):
                 if callable(exp_fn)
                 else int(model.exposure_lperiod)
             )
-        hw_max = getattr(model, "me_hardware_max_exposure", None)
-        if hw_max is not None and exposure_reg > int(hw_max):
-            logger.warning(
-                "REG_EXPOSURE %d above hardware max %d — clamping",
-                exposure_reg,
-                int(hw_max),
-            )
-            exposure_reg = int(hw_max)
+        if self._pass_manual:
+            # Explicit Scan Lab / debug override: the caller's value must
+            # reach REG_EXPOSURE verbatim, so the hardware-max clamp below
+            # (which protects driver-derived exposure) is bypassed.
+            logger.info("REG_EXPOSURE %d — manual-override, hardware-max clamp bypassed", exposure_reg)
+        else:
+            hw_max = getattr(model, "me_hardware_max_exposure", None)
+            if hw_max is not None and exposure_reg > int(hw_max):
+                logger.warning(
+                    "REG_EXPOSURE %d above hardware max %d — clamping",
+                    exposure_reg,
+                    int(hw_max),
+                )
+                exposure_reg = int(hw_max)
         self._set24(cache, r.REG_EXPOSURE, exposure_reg)
         # Image/calib acquire with FEEDL=1; positioning is a separate feed pair.
         self._set24(cache, r.REG_FEEDL, 1)
@@ -308,6 +337,8 @@ class Gl128ScanSession(ScanSession):
         infrared: bool = False,
         align_passes: bool = True,
         me_exposure_mode: str = "adaptive",
+        me_short_exposure: int | None = None,
+        me_long_exposure: int | None = None,
     ):
         from pyopticfilm.image import ScanImage
         from pyopticfilm.pass_align import align_pass_to_reference, estimate_pass_shift, warn_if_align_unavailable
@@ -320,7 +351,15 @@ class Gl128ScanSession(ScanSession):
             raise ValueError("Use mode='color' with infrared=True for colour+IR scans")
 
         model = self.model
-        exp_short = int(getattr(model, "exposure_short", model.exposure_lperiod))
+        # Manual short override replaces the model default for every early
+        # pass (color_short and, when combined, IR) — same variable those
+        # passes already shared before this feature existed.
+        short_manual = me_short_exposure is not None
+        exp_short = (
+            int(me_short_exposure)
+            if short_manual
+            else int(getattr(model, "exposure_short", model.exposure_lperiod))
+        )
         exp_long = int(getattr(model, "exposure_long", exp_short * 3))
         mode_norm = str(me_exposure_mode or "adaptive").strip().lower()
         if mode_norm not in ("adaptive", "fixed"):
@@ -337,11 +376,11 @@ class Gl128ScanSession(ScanSession):
             geometry = compute_geometry(resolution, model=model, area=area)
 
         # Short (+ optional IR) first; long exposure is chosen after short RGB.
-        early: list[tuple[str, str, int, bool, bool]] = [
-            ("color_short", "transparency", exp_short, False, False),
+        early: list[tuple[str, str, int, bool, bool, bool]] = [
+            ("color_short", "transparency", exp_short, False, False, short_manual),
         ]
         if infrared:
-            early.append(("ir", "infrared", exp_short, False, False))
+            early.append(("ir", "infrared", exp_short, False, False, short_manual))
         n_pass = len(early) + (1 if multi_exposure else 0)
 
         logger.info(
@@ -366,6 +405,7 @@ class Gl128ScanSession(ScanSession):
             exposure: int,
             remeasure: bool,
             long_pass: bool,
+            manual: bool = False,
         ):
             nonlocal rgb_short, rgb_long, ir_plane
 
@@ -394,6 +434,7 @@ class Gl128ScanSession(ScanSession):
 
             self._pass_exposure = exposure
             self._pass_long_exposure = bool(long_pass)
+            self._pass_manual = bool(manual)
             try:
                 raw = self.acquire_raw(
                     geometry,
@@ -406,6 +447,7 @@ class Gl128ScanSession(ScanSession):
             finally:
                 self._pass_exposure = None
                 self._pass_long_exposure = False
+                self._pass_manual = False
 
             use_host = (
                 calib is not None
@@ -435,7 +477,7 @@ class Gl128ScanSession(ScanSession):
             elif key == "ir":
                 ir_plane = self._infrared_plane(rgb)
 
-        for idx, (key, method, exposure, remeasure, long_pass) in enumerate(early):
+        for idx, (key, method, exposure, remeasure, long_pass, manual) in enumerate(early):
             _acquire_pass(
                 idx=idx,
                 key=key,
@@ -443,70 +485,83 @@ class Gl128ScanSession(ScanSession):
                 exposure=exposure,
                 remeasure=remeasure,
                 long_pass=long_pass,
+                manual=manual,
             )
 
         assert rgb_short is not None
 
+        long_manual = me_long_exposure is not None
         if multi_exposure:
-            # DPI-aware ME long ceiling (7200 → 42k; other PPI → 85k).
-            dpi_adaptive_max = clamp_me_long_for_dpi(
-                geometry.resolution,
-                int(getattr(model, "me_adaptive_max_exposure", exp_long)),
-            )
-            dpi_hardware_max = clamp_me_long_for_dpi(
-                geometry.resolution,
-                int(getattr(model, "me_hardware_max_exposure", exp_long)),
-            )
-            if mode_norm == "fixed":
-                exposure_decision = fixed_long_exposure(
-                    clamp_me_long_for_dpi(geometry.resolution, exp_long),
-                    short_rgb=rgb_short,
-                    short_exposure=exp_short,
-                    black_level=float(getattr(model, "me_black_level", 0.0)),
+            if long_manual:
+                # Explicit override: use the caller's value verbatim and skip
+                # adaptive/fixed selection, the DPI clamp, and the hardware-max
+                # clamp entirely — me_exposure_mode does not apply here.
+                exp_long = int(me_long_exposure)
+                logger.info(
+                    "ME long exposure: manual-override selected=%d (me_exposure_mode=%s ignored)",
+                    exp_long,
+                    mode_norm,
                 )
             else:
-                exposure_decision = select_long_exposure(
-                    rgb_short,
-                    exp_short,
-                    black_level=float(getattr(model, "me_black_level", 0.0)),
-                    dense_percentile=float(getattr(model, "me_dense_percentile", 5.0)),
-                    target_dense_dn=float(getattr(model, "me_target_dense_dn", 10000.0)),
-                    adaptive_min=int(
-                        getattr(model, "me_adaptive_min_exposure", exp_long)
-                    ),
-                    adaptive_max=dpi_adaptive_max,
-                    hardware_max=dpi_hardware_max,
-                    max_ratio=float(getattr(model, "me_max_exposure_ratio", 5.0)),
-                    default_long=clamp_me_long_for_dpi(geometry.resolution, exp_long),
-                )
-            exp_long = int(exposure_decision.selected)
-            clamped = clamp_me_long_for_dpi(geometry.resolution, exp_long)
-            if clamped != exp_long:
-                logger.warning(
-                    "ME colour-long exposure clamped at %d dpi: %d → %d",
+                # DPI-aware ME long ceiling (7200 → 42k; other PPI → 85k).
+                dpi_adaptive_max = clamp_me_long_for_dpi(
                     geometry.resolution,
-                    exp_long,
-                    clamped,
+                    int(getattr(model, "me_adaptive_max_exposure", exp_long)),
                 )
-                exp_long = clamped
-            p05 = exposure_decision.dense_p05
-            clips = exposure_decision.predicted_clip
-            logger.info(
-                "ME long exposure: short=%d  R/G/B p05=(%.0f, %.0f, %.0f)  "
-                "proposed=%d  predicted clip R/G/B=(%.2f%%, %.2f%%, %.2f%%)  "
-                "safety_max=%d  selected=%d  reason=%s",
-                exp_short,
-                p05[0],
-                p05[1],
-                p05[2],
-                exposure_decision.proposed,
-                clips[0] * 100.0,
-                clips[1] * 100.0,
-                clips[2] * 100.0,
-                dpi_hardware_max,
-                exp_long,
-                exposure_decision.reason,
-            )
+                dpi_hardware_max = clamp_me_long_for_dpi(
+                    geometry.resolution,
+                    int(getattr(model, "me_hardware_max_exposure", exp_long)),
+                )
+                if mode_norm == "fixed":
+                    exposure_decision = fixed_long_exposure(
+                        clamp_me_long_for_dpi(geometry.resolution, exp_long),
+                        short_rgb=rgb_short,
+                        short_exposure=exp_short,
+                        black_level=float(getattr(model, "me_black_level", 0.0)),
+                    )
+                else:
+                    exposure_decision = select_long_exposure(
+                        rgb_short,
+                        exp_short,
+                        black_level=float(getattr(model, "me_black_level", 0.0)),
+                        dense_percentile=float(getattr(model, "me_dense_percentile", 5.0)),
+                        target_dense_dn=float(getattr(model, "me_target_dense_dn", 10000.0)),
+                        adaptive_min=int(
+                            getattr(model, "me_adaptive_min_exposure", exp_long)
+                        ),
+                        adaptive_max=dpi_adaptive_max,
+                        hardware_max=dpi_hardware_max,
+                        max_ratio=float(getattr(model, "me_max_exposure_ratio", 5.0)),
+                        default_long=clamp_me_long_for_dpi(geometry.resolution, exp_long),
+                    )
+                exp_long = int(exposure_decision.selected)
+                clamped = clamp_me_long_for_dpi(geometry.resolution, exp_long)
+                if clamped != exp_long:
+                    logger.warning(
+                        "ME colour-long exposure clamped at %d dpi: %d → %d",
+                        geometry.resolution,
+                        exp_long,
+                        clamped,
+                    )
+                    exp_long = clamped
+                p05 = exposure_decision.dense_p05
+                clips = exposure_decision.predicted_clip
+                logger.info(
+                    "ME long exposure: short=%d  R/G/B p05=(%.0f, %.0f, %.0f)  "
+                    "proposed=%d  predicted clip R/G/B=(%.2f%%, %.2f%%, %.2f%%)  "
+                    "safety_max=%d  selected=%d  reason=%s",
+                    exp_short,
+                    p05[0],
+                    p05[1],
+                    p05[2],
+                    exposure_decision.proposed,
+                    clips[0] * 100.0,
+                    clips[1] * 100.0,
+                    clips[2] * 100.0,
+                    dpi_hardware_max,
+                    exp_long,
+                    exposure_decision.reason,
+                )
             _acquire_pass(
                 idx=len(early),
                 key="color_long",
@@ -514,6 +569,7 @@ class Gl128ScanSession(ScanSession):
                 exposure=exp_long,
                 remeasure=True,
                 long_pass=True,
+                manual=long_manual,
             )
 
         align_shift_long: tuple[float, float] | None = None
@@ -565,7 +621,9 @@ class Gl128ScanSession(ScanSession):
                     None if exposure_decision is None else exposure_decision.proposed
                 ),
                 exposure_reason=(
-                    None if exposure_decision is None else exposure_decision.reason
+                    "manual-override"
+                    if long_manual
+                    else (None if exposure_decision is None else exposure_decision.reason)
                 ),
             )
 

--- a/src/pyopticfilm/scanner.py
+++ b/src/pyopticfilm/scanner.py
@@ -22,6 +22,7 @@ from pyopticfilm.exceptions import AsicError, PlustekError
 from pyopticfilm.image import ScanImage
 from pyopticfilm.logging import get_logger
 from pyopticfilm.scan.calibrate import CalibEntry, Calibrator, default_cache_path
+from pyopticfilm.scan.exposure_override import validate_manual_exposure
 from pyopticfilm.usb.device import UsbDeviceHandle
 from pyopticfilm.usb.fake import FakeDeviceHandle, MockScannerTransport
 from pyopticfilm.usb.protocol import GenesysUsbProtocol, UsbTransport
@@ -287,7 +288,14 @@ class Scanner:
         infrared: bool = False,
         align_passes: bool = True,
         me_exposure_mode: str = "adaptive",
+        single_pass_exposure: int | None = None,
+        me_short_exposure: int | None = None,
+        me_long_exposure: int | None = None,
     ) -> ScanImage:
+        # Fail fast on bad manual-exposure input before touching the ASIC.
+        validate_manual_exposure(single_pass_exposure, label="single_pass_exposure")
+        validate_manual_exposure(me_short_exposure, label="me_short_exposure")
+        validate_manual_exposure(me_long_exposure, label="me_long_exposure")
         self._ensure_scan_ready()
         self._ensure_open()
         if not self._asic._initialized:
@@ -308,6 +316,9 @@ class Scanner:
             "infrared": infrared,
             "align_passes": align_passes,
             "me_exposure_mode": me_exposure_mode,
+            "single_pass_exposure": single_pass_exposure,
+            "me_short_exposure": me_short_exposure,
+            "me_long_exposure": me_long_exposure,
         }
         if getattr(self._model, "asic", "") == "GL128" and not self._gl128_primed:
             prime_dpi, prime_area = _gl128_prime_spec()

--- a/src/pyopticfilm/scanner.py
+++ b/src/pyopticfilm/scanner.py
@@ -44,6 +44,11 @@ logger = get_logger(__name__)
 #   unset/empty         -> default small pass (600 dpi, area (0, 0, 1, 0.12))
 #   full                -> full pass at the requested PPI and area
 #   <dpi>:x0,y0,x1,y1   -> custom pass, e.g. 600:0.0,0.0,1.0,0.12
+#
+# Scanner.scan(gl128_prime=False) skips the pass entirely for that call
+# (debug/testing only — expect ~30 px of first-scan position drift). It does
+# not mark the scanner as primed, so a later call without the override still
+# primes normally.
 _PRIME_ENV = "POF_GL128_PRIME"
 _PRIME_DEFAULT = (600, (0.0, 0.0, 1.0, 0.12))
 
@@ -67,7 +72,7 @@ def _gl128_prime_spec() -> tuple[int, tuple[float, float, float, float] | None]:
 
 
 ScanMode = Literal["color", "infrared", "gray"]
-ScanStatus = Literal["priming", "scanning"]
+ScanStatus = Literal["priming", "prime_skipped", "scanning"]
 
 
 class Scanner:
@@ -291,6 +296,7 @@ class Scanner:
         single_pass_exposure: int | None = None,
         me_short_exposure: int | None = None,
         me_long_exposure: int | None = None,
+        gl128_prime: bool = True,
     ) -> ScanImage:
         # Fail fast on bad manual-exposure input before touching the ASIC.
         validate_manual_exposure(single_pass_exposure, label="single_pass_exposure")
@@ -321,36 +327,47 @@ class Scanner:
             "me_long_exposure": me_long_exposure,
         }
         if getattr(self._model, "asic", "") == "GL128" and not self._gl128_primed:
-            prime_dpi, prime_area = _gl128_prime_spec()
-            if prime_area is None:
-                prime_area = area
-            if prime_dpi == 0:
-                prime_dpi = resolution
-            logger.info(
-                "GL128 priming pass (%s dpi, area=%s): discard first image to establish AGOHOME park "
-                "(ignores caller geometry/calib/mode)",
-                prime_dpi,
-                prime_area,
-            )
-            if on_status is not None:
-                on_status("priming")
-            # Do not spread caller kwargs: geometry= would ignore dpi/area, and
-            # apply_calib=True can add a cold shading cycle before the park.
-            prime_kwargs = {
-                "resolution": prime_dpi,
-                "mode": "color",
-                "area": prime_area,
-                "geometry": None,
-                "progress": None,
-                "cancel": None,
-                "apply_calib": False,
-                "multi_exposure": False,
-                "infrared": False,
-                "align_passes": align_passes,
-            }
-            prime_session = create_session(self._asic, self._model, self._calibrator)
-            prime_session.run(**prime_kwargs)  # type: ignore[arg-type]
-            self._gl128_primed = True
+            if not gl128_prime:
+                # Debug/testing only: skip the discarded pass for this call.
+                # _gl128_primed stays False, so a later call without the
+                # override still primes normally.
+                logger.info(
+                    "GL128 priming pass skipped (gl128_prime=False, debug/testing "
+                    "override) — first retained scan position may drift ~30px"
+                )
+                if on_status is not None:
+                    on_status("prime_skipped")
+            else:
+                prime_dpi, prime_area = _gl128_prime_spec()
+                if prime_area is None:
+                    prime_area = area
+                if prime_dpi == 0:
+                    prime_dpi = resolution
+                logger.info(
+                    "GL128 priming pass (%s dpi, area=%s): discard first image to establish AGOHOME park "
+                    "(ignores caller geometry/calib/mode)",
+                    prime_dpi,
+                    prime_area,
+                )
+                if on_status is not None:
+                    on_status("priming")
+                # Do not spread caller kwargs: geometry= would ignore dpi/area, and
+                # apply_calib=True can add a cold shading cycle before the park.
+                prime_kwargs = {
+                    "resolution": prime_dpi,
+                    "mode": "color",
+                    "area": prime_area,
+                    "geometry": None,
+                    "progress": None,
+                    "cancel": None,
+                    "apply_calib": False,
+                    "multi_exposure": False,
+                    "infrared": False,
+                    "align_passes": align_passes,
+                }
+                prime_session = create_session(self._asic, self._model, self._calibrator)
+                prime_session.run(**prime_kwargs)  # type: ignore[arg-type]
+                self._gl128_primed = True
 
         if on_status is not None:
             on_status("scanning")

--- a/tests/test_manual_exposure.py
+++ b/tests/test_manual_exposure.py
@@ -1,0 +1,301 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Manual (Scan Lab / debug) exposure overrides: validation, GL128 single-pass,
+and GL128 multi-exposure (ME) short/long behavior.
+
+Automatic/derived exposure keeps the existing adaptive envelope and hardware
+clamp; an explicitly supplied value is written to ``REG_EXPOSURE`` verbatim.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyopticfilm.device.model_8200i import MODEL_8200I
+from pyopticfilm.device.model_8200i_se import MODEL_8200I_SE
+from pyopticfilm.device.select import create_asic
+from pyopticfilm.scan.exposure_override import MAX_EXPOSURE_REGISTER, validate_manual_exposure
+from pyopticfilm.scan.geometry import compute_geometry
+from pyopticfilm.scan.session_gl128 import Gl128ScanSession
+from pyopticfilm.scanner import Scanner
+from pyopticfilm.usb.fake import MockScannerTransport
+from pyopticfilm.usb.protocol import GenesysUsbProtocol
+
+_TINY = (0.0, 0.0, 0.08, 0.08)
+
+
+def _reg_exposure(usb: MockScannerTransport) -> int:
+    return (
+        (usb.registers.get(0x7D, 0) << 16)
+        | (usb.registers.get(0x7E, 0) << 8)
+        | usb.registers.get(0x7F, 0)
+    )
+
+
+def _mock_gl128_session() -> tuple[Gl128ScanSession, MockScannerTransport]:
+    """For direct ``_configure()`` calls — motor moves off (as in test_me_gl128_configure.py)."""
+    usb = MockScannerTransport()
+    asic = create_asic(GenesysUsbProtocol(usb), MODEL_8200I_SE)
+    asic._motor_moves_enabled = False
+    asic.init()
+    return Gl128ScanSession(asic, MODEL_8200I_SE), usb
+
+
+def _mock_gl128_session_armed() -> tuple[Gl128ScanSession, MockScannerTransport]:
+    """For full ``run()`` calls — motor moves armed, required by the run() gate."""
+    usb = MockScannerTransport()
+    asic = create_asic(GenesysUsbProtocol(usb), MODEL_8200I_SE)
+    asic._motor_moves_enabled = True
+    asic.init()
+    return Gl128ScanSession(asic, MODEL_8200I_SE), usb
+
+
+# --- validation ----------------------------------------------------------
+
+
+def test_validate_manual_exposure_none_is_allowed():
+    assert validate_manual_exposure(None, label="x") is None
+
+
+def test_validate_manual_exposure_accepts_24bit_max():
+    assert validate_manual_exposure(MAX_EXPOSURE_REGISTER, label="x") == MAX_EXPOSURE_REGISTER
+
+
+@pytest.mark.parametrize("value", [0, -1, -100000])
+def test_validate_manual_exposure_rejects_non_positive(value):
+    with pytest.raises(ValueError):
+        validate_manual_exposure(value, label="x")
+
+
+def test_validate_manual_exposure_rejects_above_24bit_max():
+    with pytest.raises(ValueError):
+        validate_manual_exposure(MAX_EXPOSURE_REGISTER + 1, label="x")
+
+
+# --- single-pass: register-writing decision -------------------------------
+
+
+def test_single_pass_manual_below_hardware_max_reaches_register():
+    session, usb = _mock_gl128_session()
+    geo = compute_geometry(1200, model=MODEL_8200I_SE)
+    session._pass_exposure = 50000
+    session._pass_manual = True
+    session._configure(geo)
+    assert _reg_exposure(usb) == 50000
+
+
+def test_single_pass_manual_above_hardware_max_is_not_clamped():
+    session, usb = _mock_gl128_session()
+    assert MODEL_8200I_SE.me_hardware_max_exposure == 85000
+    geo = compute_geometry(1200, model=MODEL_8200I_SE)
+    session._pass_exposure = 100000
+    session._pass_manual = True
+    session._configure(geo)
+    assert _reg_exposure(usb) == 100000
+
+
+def test_single_pass_default_none_keeps_hardware_clamp():
+    """No override (``_pass_manual`` stays False): the existing clamp still fires."""
+    session, usb = _mock_gl128_session()
+    geo = compute_geometry(1200, model=MODEL_8200I_SE)
+    session._pass_exposure = 100000
+    session._pass_long_exposure = False
+    session._pass_manual = False
+    session._configure(geo)
+    assert _reg_exposure(usb) == MODEL_8200I_SE.me_hardware_max_exposure
+
+
+def test_single_pass_manual_state_resets_between_scans():
+    """A manual pass must not leak into a later default-exposure scan."""
+    usb = MockScannerTransport()
+    scanner = Scanner.open_fake(MODEL_8200I_SE, usb)
+    try:
+        scanner.scan(resolution=150, area=_TINY, apply_calib=False, single_pass_exposure=99999)
+        assert _reg_exposure(usb) == 99999
+
+        scanner.scan(resolution=150, area=_TINY, apply_calib=False)
+        assert _reg_exposure(usb) == MODEL_8200I_SE.exposure_short
+    finally:
+        scanner.close()
+
+
+# --- ME short: register-writing decision ----------------------------------
+
+
+def test_me_short_manual_below_hardware_max_reaches_register():
+    session, usb = _mock_gl128_session()
+    geo = compute_geometry(1800, model=MODEL_8200I_SE)
+    session._pass_exposure = 30000
+    session._pass_long_exposure = False
+    session._pass_manual = True
+    session._configure(geo)
+    assert _reg_exposure(usb) == 30000
+
+
+def test_me_short_manual_above_hardware_max_is_not_clamped():
+    session, usb = _mock_gl128_session()
+    geo = compute_geometry(1800, model=MODEL_8200I_SE)
+    session._pass_exposure = 100000
+    session._pass_long_exposure = False
+    session._pass_manual = True
+    session._configure(geo)
+    assert _reg_exposure(usb) == 100000
+
+
+def test_me_short_default_none_uses_model_derived_value():
+    session, _usb = _mock_gl128_session_armed()
+    session.run(resolution=1800, area=_TINY, apply_calib=False, multi_exposure=True)
+    assert session.last_me_debug.exposure_short == MODEL_8200I_SE.exposure_short
+
+
+# --- ME long: adaptive/DPI/hardware clamps bypassed end-to-end ------------
+
+
+def test_me_long_manual_below_normal_limits_not_raised_to_adaptive_floor():
+    session, _usb = _mock_gl128_session_armed()
+    session.run(
+        resolution=1800,
+        area=_TINY,
+        apply_calib=False,
+        multi_exposure=True,
+        me_long_exposure=5000,  # below the 14000 floor / 42000 adaptive minimum
+    )
+    assert session.last_me_debug.exposure_long == 5000
+
+
+def test_me_long_manual_skips_dpi_and_hardware_clamp_and_reaches_register():
+    """7200 dpi normally caps ME long at 42000; hardware max is 85000 — go above both."""
+    session, usb = _mock_gl128_session_armed()
+    captures: list[tuple[bool, bool, int]] = []
+    original_configure = session._configure
+
+    def spy(geometry):
+        original_configure(geometry)
+        captures.append((session._pass_long_exposure, session._pass_manual, _reg_exposure(usb)))
+
+    session._configure = spy  # type: ignore[method-assign]
+
+    session.run(
+        resolution=7200,
+        area=_TINY,
+        apply_calib=False,
+        multi_exposure=True,
+        me_long_exposure=150000,
+    )
+
+    long_captures = [c for c in captures if c[0]]
+    assert long_captures, "expected a long pass to run"
+    _long_pass, manual, reg_value = long_captures[-1]
+    assert manual is True
+    assert reg_value == 150000
+    assert session.last_me_debug.exposure_long == 150000
+    assert session.last_me_debug.exposure_reason == "manual-override"
+    assert session.last_me_debug.exposure_proposed is None
+
+
+@pytest.mark.parametrize("me_exposure_mode", ["adaptive", "fixed"])
+def test_me_long_manual_overrides_exposure_mode(me_exposure_mode):
+    """``me_exposure_mode='adaptive'`` + ``me_long_exposure=120000`` -> 120000, not adaptive."""
+    session, _usb = _mock_gl128_session_armed()
+    session.run(
+        resolution=1800,
+        area=_TINY,
+        apply_calib=False,
+        multi_exposure=True,
+        me_exposure_mode=me_exposure_mode,
+        me_long_exposure=120000,
+    )
+    assert session.last_me_debug.exposure_long == 120000
+    assert session.last_me_debug.exposure_reason == "manual-override"
+
+
+def test_me_long_default_none_uses_adaptive_selection():
+    session, _usb = _mock_gl128_session_armed()
+    session.run(
+        resolution=1800,
+        area=_TINY,
+        apply_calib=False,
+        multi_exposure=True,
+        me_exposure_mode="adaptive",
+    )
+    debug = session.last_me_debug
+    assert debug.exposure_reason != "manual-override"
+    assert debug.exposure_proposed is not None
+    assert 14000 <= debug.exposure_long <= MODEL_8200I_SE.me_hardware_max_exposure
+
+
+def test_me_long_default_none_uses_fixed_selection():
+    session, _usb = _mock_gl128_session_armed()
+    session.run(
+        resolution=1800,
+        area=_TINY,
+        apply_calib=False,
+        multi_exposure=True,
+        me_exposure_mode="fixed",
+    )
+    debug = session.last_me_debug
+    assert debug.exposure_reason == "fixed"
+    assert debug.exposure_long == 42000
+
+
+# --- Scanner.scan() wiring: prime pass must not inherit overrides ---------
+
+
+def test_scanner_scan_threads_manual_exposure_to_session_not_prime(monkeypatch):
+    import pyopticfilm.scan.session as session_module
+
+    scanner = Scanner.open_fake(MODEL_8200I_SE)
+    sentinel = object()
+    runs: list[dict[str, object]] = []
+
+    class FakeSession:
+        last_me_debug = None
+
+        def run(self, **kwargs):
+            runs.append(kwargs)
+            return sentinel
+
+    monkeypatch.setattr(session_module, "create_session", lambda *args: FakeSession())
+    monkeypatch.delenv("POF_GL128_PRIME", raising=False)
+    try:
+        result = scanner.scan(
+            resolution=150,
+            area=_TINY,
+            apply_calib=False,
+            single_pass_exposure=12345,
+            me_short_exposure=6789,
+            me_long_exposure=99999,
+        )
+    finally:
+        scanner.close()
+
+    assert result is sentinel
+    assert len(runs) == 2
+    prime_kwargs, scan_kwargs = runs
+    assert "single_pass_exposure" not in prime_kwargs
+    assert "me_short_exposure" not in prime_kwargs
+    assert "me_long_exposure" not in prime_kwargs
+    assert scan_kwargs["single_pass_exposure"] == 12345
+    assert scan_kwargs["me_short_exposure"] == 6789
+    assert scan_kwargs["me_long_exposure"] == 99999
+
+
+def test_scanner_scan_rejects_invalid_manual_exposure_before_opening_asic():
+    scanner = Scanner.open_fake(MODEL_8200I_SE)
+    try:
+        with pytest.raises(ValueError):
+            scanner.scan(resolution=150, area=_TINY, apply_calib=False, me_long_exposure=-5)
+        assert not scanner._asic._initialized
+    finally:
+        scanner.close()
+
+
+# --- base session compatibility (non-GL128) -------------------------------
+
+
+def test_scanner_scan_single_pass_exposure_not_implemented_for_non_gl128():
+    scanner = Scanner.open_fake(MODEL_8200I)
+    try:
+        with pytest.raises(NotImplementedError):
+            scanner.scan(resolution=900, area=_TINY, apply_calib=False, single_pass_exposure=5000)
+    finally:
+        scanner.close()

--- a/tests/test_mock_scan.py
+++ b/tests/test_mock_scan.py
@@ -141,6 +141,55 @@ def test_gl128_scanner_primes_once_before_first_requested_scan(monkeypatch):
         scanner.close()
 
 
+def test_gl128_prime_skipped_when_gl128_prime_false(monkeypatch):
+    """gl128_prime=False skips the discarded pass for that call only."""
+    import pyopticfilm.scan.session as session_module
+
+    scanner = Scanner.open_fake(MODEL_8200I_SE)
+    runs: list[dict[str, object]] = []
+    statuses: list[str] = []
+
+    class FakeSession:
+        last_me_debug = None
+
+        def run(self, **kwargs):
+            runs.append(kwargs)
+            return object()
+
+    monkeypatch.setattr(session_module, "create_session", lambda *args: FakeSession())
+    monkeypatch.delenv("POF_GL128_PRIME", raising=False)
+    try:
+        scanner.scan(
+            resolution=150,
+            area=_TINY,
+            apply_calib=False,
+            on_status=statuses.append,
+            gl128_prime=False,
+        )
+        # Only the retained scan ran — no discarded prime pass.
+        assert len(runs) == 1
+        assert runs[0]["resolution"] == 150
+        assert statuses == ["prime_skipped", "scanning"]
+        assert scanner._gl128_primed is False
+
+        # A later call without the override still primes normally, since
+        # skipping never marked the scanner as primed.
+        statuses.clear()
+        scanner.scan(
+            resolution=150,
+            area=_TINY,
+            apply_calib=False,
+            on_status=statuses.append,
+        )
+        assert len(runs) == 3
+        assert runs[1]["resolution"] == 600  # the (now-run) discarded prime
+        assert runs[2]["resolution"] == 150
+        assert statuses == ["priming", "scanning"]
+        assert scanner._gl128_primed is True
+    finally:
+        scanner.close()
+
+
 def test_gl128_prime_ignores_caller_geometry_and_calib(monkeypatch):
     """Caller geometry/apply_calib must not stretch the discarded AGOHOME pass."""
     import pyopticfilm.scan.session as session_module

--- a/tests/test_scanlab_worker.py
+++ b/tests/test_scanlab_worker.py
@@ -35,12 +35,13 @@ def test_run_scan_accepts_positional_signal_args():
         "single_pass_exposure",
         "me_short_exposure",
         "me_long_exposure",
+        "gl128_prime",
     ]
     assert keyword_only == []
 
 
 def test_run_prescan_accepts_positional_signal_args():
-    # request_prescan = pyqtSignal(object, bool)
+    # request_prescan = pyqtSignal(object, bool, bool)
     positional, keyword_only = _method_args("run_prescan")
-    assert positional == ["target", "apply_calib"]
+    assert positional == ["target", "apply_calib", "gl128_prime"]
     assert keyword_only == []

--- a/tests/test_scanlab_worker.py
+++ b/tests/test_scanlab_worker.py
@@ -32,6 +32,9 @@ def test_run_scan_accepts_positional_signal_args():
         "crop_norm",
         "apply_calib",
         "me_exposure_mode",
+        "single_pass_exposure",
+        "me_short_exposure",
+        "me_long_exposure",
     ]
     assert keyword_only == []
 

--- a/tools/scanlab/README.md
+++ b/tools/scanlab/README.md
@@ -96,6 +96,7 @@ scan-ready GL128 **8100 (V2)** (`07b3:1824`).
 | **IR pass** | After colour Scan, run a second infrared pass (disabled if the model has no IR). |
 | **Multi-exposure (ME)** | GL128 / hardware-tested models: short + adaptive long colour passes (42k–85k safety envelope, capped at 42000 at 7200 dpi; fallback 42000); host SNR/IVW merge into ``rgb``. Bracket planes on ``Scanner.last_me_debug`` (not ``ScanImage``). |
 | **Fixed 42k long (A/B)** | When ME is on: force SilverFast-style long exposure 42000 instead of adaptive selection. |
+| **Manual exposure overrides** | GL128 debug/testing only — see [Manual exposure overrides](#manual-exposure-overrides) below. |
 | **Prescan** | Low-res preview (GL128: 1200 dpi safe window; non-scan-ready: lowest dpi + short Y strip). |
 | **Scan** | Colour scan at the chosen PPI; optional IR and/or ME. Uses the prescan crop when one is set (clamped on non-scan-ready). |
 | **Open capture…** | Open a USBPcap ``.pcap`` / ``.pcapng``. Decodes the largest bulk IN through the selected model’s image pipeline and diffs FEEDL / LINCNT / DPISET vs Lab geometry (Capture tab). |
@@ -103,6 +104,29 @@ scan-ready GL128 **8100 (V2)** (`07b3:1824`).
 
 The yellow banner states MOCK vs REAL for the current selection (HW gate override
 and USB RGB layout when relevant).
+
+## Manual exposure overrides
+
+Three GL128-only text fields let Scan Lab send an exact `REG_EXPOSURE` value for
+debugging/testing, bypassing the driver's normal soft limits:
+
+| Field | Controls | Empty (default) |
+|-------|----------|------------------|
+| **Single-pass exposure** | The retained Scan pass when ME is off. | Model-derived exposure, still clamped to the hardware max. |
+| **ME short exposure** | The ME short pass only. | Model-derived short exposure, still clamped to the hardware max. |
+| **ME long exposure** | The ME long pass only; overrides **Adaptive**/**Fixed 42k long** entirely. | Normal Adaptive/Fixed selection (42k–85k envelope, DPI clamp). |
+
+Each field is grayed out when it does not apply to the current pass selection
+(e.g. the single-pass field while ME is on). A value is written to
+`REG_EXPOSURE` **verbatim** — it skips the adaptive selection, the DPI clamp,
+and the hardware-max clamp that apply to normal (automatic) exposure. The only
+limit enforced is the actual 24-bit register range (1–16777215 / `0xFFFFFF`);
+an out-of-range value is rejected with a clear error rather than clamped.
+
+These overrides exist for hardware/debugging experiments — an excessive value
+can produce severe overexposure/clipping, and the software intentionally does
+not prevent that. They apply only to the retained Scan pass, never to the
+discarded GL128 priming pass.
 
 ## Tabs
 

--- a/tools/scanlab/README.md
+++ b/tools/scanlab/README.md
@@ -91,6 +91,7 @@ scan-ready GL128 **8100 (V2)** (`07b3:1824`).
 | **USB planar RGB** | Off = chunky `RGBRGB…` (default). On = planar planes — try this if Prescan is rainbow-striped. |
 | **Adaptive quiet drain** | On (default). Rate-limits host bulk reads to the ASIC `LPERIOD` line rate (including 7200 dpi, ~3.55 ms/line) so motor creep stays continuous. Uncheck for fastest drain (louder). |
 | **Slow image slope** | Off (default). On: shading/slow motor ramp on the image pass (feeds stay fast). |
+| **Disable priming pass (debug)** | GL128 only. Off (default). On: skip the discarded first-scan AGOHOME-park pass on both Prescan and Scan — debug/testing only, expect ~30 px of first-scan position drift. Unchecking it lets the scanner prime normally on the next Prescan/Scan. |
 | **Refresh devices** | Re-enumerate USB and rebuild the device list. |
 | **PPI** | Resolutions from the selected model’s `resolutions_dpi` (Scan only; Prescan uses a fixed low dpi). |
 | **IR pass** | After colour Scan, run a second infrared pass (disabled if the model has no IR). |
@@ -191,13 +192,14 @@ Live truncated log of every control and bulk transfer through the recording
 USB wrapper. **Open capture…** also fills this tab from the pcap (identical
 line format; repeated bulk-IN lengths are collapsed as ``×N``).
 
-- Dividers mark `PRIMING`, `PRESCAN`, `SCAN`, `IR`, and `CAPTURE` sections.
+- Dividers mark `PRIMING` (or `PRIMING SKIPPED (debug)` when **Disable priming pass** is on), `PRESCAN`, `SCAN`, `IR`, and `CAPTURE` sections.
 - **Jump** buttons scroll to those dividers when present.
 - **Clear USB log** empties the buffer (Prescan also clears the log).
 
 Progress for the active pass is shown in the status bar. On the first scan
 after open (GL128), the status bar shows **Priming scanner…** while the
-discarded AGOHOME park pass runs, then **Scanning…**.
+discarded AGOHOME park pass runs, then **Scanning…** — or **Priming skipped
+(debug)…** when **Disable priming pass (debug)** is checked.
 
 ## Geometry notes
 

--- a/tools/scanlab/app.py
+++ b/tools/scanlab/app.py
@@ -6,13 +6,14 @@ from __future__ import annotations
 from pathlib import Path
 
 from PyQt6.QtCore import Qt, QThread
-from PyQt6.QtGui import QTextCursor
+from PyQt6.QtGui import QIntValidator, QTextCursor
 from PyQt6.QtWidgets import (
     QCheckBox,
     QComboBox,
     QFileDialog,
     QHBoxLayout,
     QLabel,
+    QLineEdit,
     QMainWindow,
     QMessageBox,
     QPlainTextEdit,
@@ -25,6 +26,7 @@ from PyQt6.QtWidgets import (
 )
 
 from pyopticfilm.image import ScanImage
+from pyopticfilm.scan.exposure_override import MAX_EXPOSURE_REGISTER
 from tools.scanlab.backend import (
     LabTarget,
     device_banner,
@@ -148,6 +150,47 @@ class ScanLabWindow(QMainWindow):
         )
         self.me_fixed_long.setEnabled(False)
         form.addWidget(self.me_fixed_long)
+
+        # Manual exposure overrides (GL128 debug/testing only): empty means
+        # normal driver behavior; a value bypasses the driver's soft
+        # adaptive/hardware-max clamps and is written to REG_EXPOSURE as-is
+        # (still limited to the 24-bit register range, 1..0xFFFFFF).
+        self._exposure_validator = QIntValidator(1, MAX_EXPOSURE_REGISTER, self)
+
+        form.addWidget(QLabel("Manual exposure overrides (debug — bypasses safety clamps)"))
+
+        self.single_pass_exposure = QLineEdit()
+        self.single_pass_exposure.setPlaceholderText("auto (non-ME Scan)")
+        self.single_pass_exposure.setValidator(self._exposure_validator)
+        self.single_pass_exposure.setToolTip(
+            "REG_EXPOSURE for a single (non-ME) Scan pass. Empty = normal "
+            "driver-derived exposure with the hardware-max clamp. A value "
+            "here is written verbatim, bypassing that clamp — up to "
+            f"{MAX_EXPOSURE_REGISTER} (0x{MAX_EXPOSURE_REGISTER:06X})."
+        )
+        form.addWidget(self.single_pass_exposure)
+
+        self.me_short_exposure = QLineEdit()
+        self.me_short_exposure.setPlaceholderText("auto (ME short)")
+        self.me_short_exposure.setValidator(self._exposure_validator)
+        self.me_short_exposure.setToolTip(
+            "REG_EXPOSURE for the ME short pass. Empty = model-derived short "
+            "exposure. A value here bypasses the hardware-max clamp."
+        )
+        self.me_short_exposure.setEnabled(False)
+        form.addWidget(self.me_short_exposure)
+
+        self.me_long_exposure = QLineEdit()
+        self.me_long_exposure.setPlaceholderText("auto (ME long)")
+        self.me_long_exposure.setValidator(self._exposure_validator)
+        self.me_long_exposure.setToolTip(
+            "REG_EXPOSURE for the ME long pass. Empty = normal Adaptive/Fixed "
+            "selection (see Fixed 42k long above). A value here overrides "
+            "Adaptive/Fixed entirely, skips the DPI/adaptive/hardware-max "
+            "clamps, and is written verbatim."
+        )
+        self.me_long_exposure.setEnabled(False)
+        form.addWidget(self.me_long_exposure)
 
         self.me_pass.toggled.connect(self._on_me_pass_toggled)
 
@@ -294,6 +337,7 @@ class ScanLabWindow(QMainWindow):
         self.me_fixed_long.setEnabled(is_gl128 and self.me_pass.isChecked())
         if not self.me_fixed_long.isEnabled():
             self.me_fixed_long.setChecked(False)
+        self._sync_manual_exposure_enabled()
         self._update_me_tabs_visible()
         self._refresh_banner()
         self.prescan_view.clear_crop()
@@ -386,10 +430,31 @@ class ScanLabWindow(QMainWindow):
         return msg
 
     def _on_me_pass_toggled(self, checked: bool) -> None:
-        self.me_fixed_long.setEnabled(bool(checked) and self.me_pass.isEnabled())
+        checked = bool(checked)
+        self.me_fixed_long.setEnabled(checked and self.me_pass.isEnabled())
         if not checked:
             self.me_fixed_long.setChecked(False)
+        self._sync_manual_exposure_enabled()
+        # ME on/off changes which override applies — drop the one that no
+        # longer makes sense rather than leaving a hidden value to surprise
+        # a later scan.
+        stale = (self.me_short_exposure, self.me_long_exposure) if not checked else (self.single_pass_exposure,)
+        for edit in stale:
+            edit.clear()
         self._update_me_tabs_visible()
+
+    def _sync_manual_exposure_enabled(self) -> None:
+        """Manual overrides only apply to the pass they name — gray out the rest."""
+        me_active = self.me_pass.isEnabled() and self.me_pass.isChecked()
+        self.single_pass_exposure.setEnabled(self.me_pass.isEnabled() and not me_active)
+        self.me_short_exposure.setEnabled(me_active)
+        self.me_long_exposure.setEnabled(me_active)
+
+    def _manual_exposure_value(self, edit: QLineEdit) -> int | None:
+        if not edit.isEnabled():
+            return None
+        text = edit.text().strip()
+        return int(text) if text else None
 
     def _default_dpi(self) -> int:
         data = self.ppi.currentData()
@@ -810,6 +875,18 @@ class ScanLabWindow(QMainWindow):
             )
             if reply != QMessageBox.StandardButton.Ok:
                 return
+        try:
+            single_pass_exposure = self._manual_exposure_value(self.single_pass_exposure)
+            me_short_exposure = self._manual_exposure_value(self.me_short_exposure)
+            me_long_exposure = self._manual_exposure_value(self.me_long_exposure)
+        except ValueError:
+            QMessageBox.warning(
+                self,
+                "Manual exposure",
+                "Manual exposure overrides must be empty or a whole number "
+                f"between 1 and {MAX_EXPOSURE_REGISTER}.",
+            )
+            return
         self._pending_crop_meta = None
         if crop is not None:
             self._pending_crop_meta = lab_crop_scan_meta(
@@ -823,6 +900,9 @@ class ScanLabWindow(QMainWindow):
             crop,
             self.apply_calib.isChecked(),
             "fixed" if self.me_fixed_long.isChecked() else "adaptive",
+            single_pass_exposure,
+            me_short_exposure,
+            me_long_exposure,
         )
 
     def _on_progress(self, value: float) -> None:
@@ -982,6 +1062,7 @@ class ScanLabWindow(QMainWindow):
         self.me_fixed_long.setEnabled(
             not busy and is_gl128 and self.me_pass.isChecked()
         )
+        self._sync_manual_exposure_enabled()
         self.run_mock.setEnabled(not busy)
         self.override_hw_gate.setEnabled(not busy)
         self.apply_calib.setEnabled(not busy)

--- a/tools/scanlab/app.py
+++ b/tools/scanlab/app.py
@@ -129,6 +129,18 @@ class ScanLabWindow(QMainWindow):
         )
         form.addWidget(self.slow_image_slope)
 
+        self.disable_gl128_prime = QCheckBox("Disable priming pass (debug)")
+        self.disable_gl128_prime.setChecked(False)
+        self.disable_gl128_prime.setToolTip(
+            "GL128 only. Off (default): the first Prescan/Scan after open runs "
+            "a discarded small pass that establishes the repeatable AGOHOME "
+            "park position. On: skip that pass — for debugging/testing only; "
+            "expect ~30 px of first-scan position drift versus the primed "
+            "baseline. The scanner still primes normally on a later "
+            "Prescan/Scan once this is unchecked again."
+        )
+        form.addWidget(self.disable_gl128_prime)
+
         refresh = QPushButton("Refresh devices")
         refresh.clicked.connect(self.reload_devices)
         form.addWidget(refresh)
@@ -847,7 +859,11 @@ class ScanLabWindow(QMainWindow):
         self._clear_usb_log()
         self._clear_scan_tabs()
         self.statusBar().showMessage("Prescanning…")
-        self._worker.request_prescan.emit(target, self.apply_calib.isChecked())
+        self._worker.request_prescan.emit(
+            target,
+            self.apply_calib.isChecked(),
+            not self.disable_gl128_prime.isChecked(),
+        )
 
     def _on_scan(self) -> None:
         target = self._resolved_target()
@@ -903,6 +919,7 @@ class ScanLabWindow(QMainWindow):
             single_pass_exposure,
             me_short_exposure,
             me_long_exposure,
+            not self.disable_gl128_prime.isChecked(),
         )
 
     def _on_progress(self, value: float) -> None:
@@ -911,6 +928,8 @@ class ScanLabWindow(QMainWindow):
     def _on_scan_status(self, status: str) -> None:
         if status == "priming":
             self.statusBar().showMessage("Priming scanner…")
+        elif status == "prime_skipped":
+            self.statusBar().showMessage("Priming skipped (debug)…")
         elif status == "scanning":
             self.statusBar().showMessage("Scanning…")
 
@@ -1070,6 +1089,7 @@ class ScanLabWindow(QMainWindow):
         self.usb_planar.setEnabled(not busy)
         self.quiet_usb_pace.setEnabled(not busy)
         self.slow_image_slope.setEnabled(not busy)
+        self.disable_gl128_prime.setEnabled(not busy)
         self.btn_open_capture.setEnabled(not busy)
 
 

--- a/tools/scanlab/worker.py
+++ b/tools/scanlab/worker.py
@@ -36,8 +36,9 @@ class ScanWorker(QObject):
     calib_cleared = pyqtSignal(str)
     #: target, apply_calib
     request_prescan = pyqtSignal(object, bool)
-    #: target, dpi, ir_pass, me_pass, crop_norm, apply_calib, me_exposure_mode
-    request_scan = pyqtSignal(object, int, bool, bool, object, bool, str)
+    #: target, dpi, ir_pass, me_pass, crop_norm, apply_calib, me_exposure_mode,
+    #: single_pass_exposure, me_short_exposure, me_long_exposure
+    request_scan = pyqtSignal(object, int, bool, bool, object, bool, str, object, object, object)
 
     def __init__(self) -> None:
         super().__init__()
@@ -127,6 +128,9 @@ class ScanWorker(QObject):
         crop_norm: tuple[float, float, float, float] | None,
         apply_calib: bool = False,
         me_exposure_mode: str = "adaptive",
+        single_pass_exposure: int | None = None,
+        me_short_exposure: int | None = None,
+        me_long_exposure: int | None = None,
     ) -> None:
         self._run(
             target,
@@ -137,6 +141,9 @@ class ScanWorker(QObject):
             crop=crop_norm,
             apply_calib=bool(apply_calib),
             me_exposure_mode=str(me_exposure_mode or "adaptive"),
+            single_pass_exposure=single_pass_exposure,
+            me_short_exposure=me_short_exposure,
+            me_long_exposure=me_long_exposure,
         )
 
     def _run(
@@ -150,6 +157,9 @@ class ScanWorker(QObject):
         crop: tuple[float, float, float, float] | None,
         apply_calib: bool,
         me_exposure_mode: str = "adaptive",
+        single_pass_exposure: int | None = None,
+        me_short_exposure: int | None = None,
+        me_long_exposure: int | None = None,
     ) -> None:
         self.busy_changed.emit(True)
         self._cancel.clear()
@@ -187,6 +197,9 @@ class ScanWorker(QObject):
                     multi_exposure=me,
                     infrared=ir,
                     me_exposure_mode=me_exposure_mode,
+                    single_pass_exposure=single_pass_exposure,
+                    me_short_exposure=me_short_exposure,
+                    me_long_exposure=me_long_exposure,
                     **scan_kw,
                 )
                 self.me_debug_ready.emit(getattr(scanner, "last_me_debug", None))

--- a/tools/scanlab/worker.py
+++ b/tools/scanlab/worker.py
@@ -34,11 +34,11 @@ class ScanWorker(QObject):
     failed = pyqtSignal(str)
     busy_changed = pyqtSignal(bool)
     calib_cleared = pyqtSignal(str)
-    #: target, apply_calib
-    request_prescan = pyqtSignal(object, bool)
+    #: target, apply_calib, gl128_prime
+    request_prescan = pyqtSignal(object, bool, bool)
     #: target, dpi, ir_pass, me_pass, crop_norm, apply_calib, me_exposure_mode,
-    #: single_pass_exposure, me_short_exposure, me_long_exposure
-    request_scan = pyqtSignal(object, int, bool, bool, object, bool, str, object, object, object)
+    #: single_pass_exposure, me_short_exposure, me_long_exposure, gl128_prime
+    request_scan = pyqtSignal(object, int, bool, bool, object, bool, str, object, object, object, bool)
 
     def __init__(self) -> None:
         super().__init__()
@@ -58,6 +58,8 @@ class ScanWorker(QObject):
     def _on_status(self, status: str) -> None:
         if status == "priming":
             self._usb_divider("PRIMING")
+        elif status == "prime_skipped":
+            self._usb_divider("PRIMING SKIPPED (debug)")
         self.status_changed.emit(status)
 
     def _usb_divider(self, title: str) -> None:
@@ -108,7 +110,12 @@ class ScanWorker(QObject):
     def cancel(self) -> None:
         self._cancel.set()
 
-    def run_prescan(self, target: LabTarget, apply_calib: bool = False) -> None:
+    def run_prescan(
+        self,
+        target: LabTarget,
+        apply_calib: bool = False,
+        gl128_prime: bool = True,
+    ) -> None:
         self._run(
             target,
             kind="prescan",
@@ -117,6 +124,7 @@ class ScanWorker(QObject):
             me=False,
             crop=None,
             apply_calib=bool(apply_calib),
+            gl128_prime=bool(gl128_prime),
         )
 
     def run_scan(
@@ -131,6 +139,7 @@ class ScanWorker(QObject):
         single_pass_exposure: int | None = None,
         me_short_exposure: int | None = None,
         me_long_exposure: int | None = None,
+        gl128_prime: bool = True,
     ) -> None:
         self._run(
             target,
@@ -144,6 +153,7 @@ class ScanWorker(QObject):
             single_pass_exposure=single_pass_exposure,
             me_short_exposure=me_short_exposure,
             me_long_exposure=me_long_exposure,
+            gl128_prime=bool(gl128_prime),
         )
 
     def _run(
@@ -160,6 +170,7 @@ class ScanWorker(QObject):
         single_pass_exposure: int | None = None,
         me_short_exposure: int | None = None,
         me_long_exposure: int | None = None,
+        gl128_prime: bool = True,
     ) -> None:
         self.busy_changed.emit(True)
         self._cancel.clear()
@@ -177,6 +188,7 @@ class ScanWorker(QObject):
                     on_status=self._on_status,
                     apply_calib=apply_calib,
                     multi_exposure=me,
+                    gl128_prime=gl128_prime,
                     **scan_kw,
                 )
                 self.prescan_ready.emit(image)
@@ -200,6 +212,7 @@ class ScanWorker(QObject):
                     single_pass_exposure=single_pass_exposure,
                     me_short_exposure=me_short_exposure,
                     me_long_exposure=me_long_exposure,
+                    gl128_prime=gl128_prime,
                     **scan_kw,
                 )
                 self.me_debug_ready.emit(getattr(scanner, "last_me_debug", None))


### PR DESCRIPTION
## What & why

Scan Lab sometimes needs to step outside the driver's normal safety envelope on purpose — send an exposure value the adaptive/hardware-max clamps would otherwise reject, or skip the GL128 priming pass to isolate whether it's actually responsible for a symptom being debugged. There was no way to do either without editing driver internals. This is helpful when validating new hardware and recent debugging/validating from GUI. Properly integrated with backwards compatability, but could be exposed in other software such as Manual Exposure in Negpy under an advanced UI need be.

This PR adds two independent, opt-in debug/testing controls to the GL128 scan path. Both default to today's exact behavior and are implemented as real `Scanner` / `Gl128ScanSession` API, not a Scan-Lab-only hack.

## 1. Manual exposure overrides

`Scanner.scan(single_pass_exposure=…, me_short_exposure=…, me_long_exposure=…)`:

- **Automatic (all `None`, default):** unchanged — the adaptive ME envelope (`select_long_exposure`, DPI clamp) and the `me_hardware_max_exposure` register clamp still apply exactly as before.
- **Explicit (a value given):** written to `REG_EXPOSURE` verbatim for that pass, bypassing those soft clamps. `me_long_exposure` takes precedence over `me_exposure_mode`.
- **Hard limit:** only the real 24-bit register range (`1..0xFFFFFF`), validated up front (`ValueError`, never silently clamped or wrapped) — no artificial software ceiling like 85000.
- Scoped per pass (`Gl128ScanSession._pass_manual`), no global state; the discarded GL128 priming pass never sees these values.

## 2. Priming-pass skip

`Scanner.scan(gl128_prime: bool = True)` — `False` skips the discarded first-scan AGOHOME-park pass for that one call. It does **not** mark the scanner as primed, so a later call without the override still primes normally: turning the flag off doesn't silently disable priming for the rest of the session. Adds `"prime_skipped"` to `ScanStatus`.

## Scan Lab

Matching UI: three manual-exposure fields (gray out when not applicable to the current pass mode) and a "Disable priming pass (debug)" checkbox, wired through both Prescan and Scan.

## Testing

**Automated:** `tests/test_manual_exposure.py` (22 cases — validation, register-writing decisions above/below the old limits, `me_exposure_mode` precedence, `Scanner.scan()` wiring and prime-pass isolation), plus `tests/test_mock_scan.py` / `tests/test_scanlab_worker.py` for the priming-skip path and signal signatures. `ruff check .` and `pytest -q` both pass (233 passed, 1 pre-existing/unrelated skip).

**Hardware:** the priming-skip toggle got real validation on a physical OpticFilm 8100 (V2) during an unrelated debugging session — used repeatedly to rule priming in or out while chasing a 7200 dpi image-corruption bug. It skipped and re-primed cleanly every time, and helped isolate that the actual cause was a separate V2 timing-constant issue ([jboneng/pyopticfilm#30](https://github.com/jboneng/pyopticfilm/pull/30)). The manual exposure fields are covered by the automated suite above but haven't had an equivalent hands-on hardware pass yet.

