### PR TITLE
Add GL128 scan-drift benchmarking tools (crop-scan sweep + phase-correlation analysis)

### DIFF
--- a/src/pyopticfilm/asic/gl128.py
+++ b/src/pyopticfilm/asic/gl128.py
@@ -204,6 +204,18 @@ class Gl128:
         #: Set after a successful :meth:`run_asic_shading` upload this session.
         #: IR Lab never sets this — ASIC DVDSET clipped IR to full scale.
         self.asic_shading_ready = False
+        #: EXPERIMENTAL, default off. Positioning feeds (home->reference,
+        #: reference->scan-start) always upload SLOPE_TABLE_FAST — the
+        #: fastest ramp in the whole capture set, real vendor-driver
+        #: behavior, never toggled by anything (unlike the image-pass creep,
+        #: which already has ``image_slope_slow``). A benchmark found
+        #: ~8px mean / up to 220px max Y-only drift between otherwise
+        #: identical repeat scans, consistent with occasional lost steps
+        #: during an aggressive feed ramp. Flip this on to try
+        #: SLOPE_TABLE_SLOW for feeds instead and A/B the drift before
+        #: considering it for a real fix — this changes real hardware motor
+        #: behavior, not just image processing.
+        self.experimental_feed_slope_slow: bool = False
         #: Equalized per-column IR white (one value/column) for host flatten.
         self.last_ir_host_white: list[int] | None = None
         #: True when :attr:`last_ir_host_white` passed the IR validator.
@@ -1087,8 +1099,8 @@ class Gl128:
         unity→white window (session 03/04: exposure AHB only).
 
         When ``image_slope_slow`` is set (Scan Lab acoustic probe), non-shading
-        uploads also use the slow ramp. Fast feeds still call
-        :meth:`_upload_fast_slopes` directly.
+        uploads also use the slow ramp. Feeds still call
+        :meth:`_upload_feed_slopes` directly (see ``experimental_feed_slope_slow``).
         """
         r = self.registers
         if slope:
@@ -1284,9 +1296,14 @@ class Gl128:
             )
         return int(limit_mm * self.model.feed_steps_per_inch / MM_PER_INCH)
 
-    def _upload_fast_slopes(self) -> None:
-        """Upload the fast motor ramp to both AHB slope windows."""
-        slope = _u16_table_bytes(SLOPE_TABLE_FAST)
+    def _upload_feed_slopes(self) -> None:
+        """Upload the feed motor ramp to both AHB slope windows.
+
+        Real vendor behavior is always ``SLOPE_TABLE_FAST`` here. See
+        ``experimental_feed_slope_slow`` for the (unconfirmed) A/B toggle.
+        """
+        use_slow = getattr(self, "experimental_feed_slope_slow", False)
+        slope = _u16_table_bytes(SLOPE_TABLE_SLOW if use_slow else SLOPE_TABLE_FAST)
         r = self.registers
         self.protocol.write_ahb(r.AHB_SLOPE_SCAN, slope)
         self.protocol.write_ahb(r.AHB_SLOPE_FAST, slope)
@@ -1337,7 +1354,7 @@ class Gl128:
         self._write_many(setup)
         self.protocol.write_u24(r.REG_FEEDL, steps)
         self._write(r.REG_0x02, r.MTRPWR | r.FASTFED)  # 0x18
-        self._upload_fast_slopes()
+        self._upload_feed_slopes()
         # This recipe deliberately does not clear the counter, so the probe and
         # FEEDFSH still carry the previous feed's completion. Sample them now so
         # the wait below knows not to believe the first "done" it sees.

--- a/tools/analyze_scan_sweep.py
+++ b/tools/analyze_scan_sweep.py
@@ -14,10 +14,19 @@ pyopticfilm.pass_align.estimate_pass_shift on purpose: that function silently
 returns (0, 0) for shifts above a ~2% guard, which would hide exactly the
 kind of large drift (e.g. priming on/off) this tool exists to surface.
 
+Reports dx/dy separately, not just combined magnitude: Y-axis drift
+implicates motor/carriage position (what priming addresses); X-axis drift
+points somewhere else (e.g. pixel/line timing). ``--verbose`` also prints
+each group's raw per-pair shifts, so you can see *where* in the repeat
+sequence drift happens — concentrated in repeat 1->2 (the "first scan after
+open" case priming is documented to fix) vs spread evenly across all pairs
+(a different, ongoing problem).
+
 Usage (from repo root)::
 
     uv run python tools/analyze_scan_sweep.py scan_sweep_20260829T120000Z/
     uv run python tools/analyze_scan_sweep.py scan_sweep_20260829T120000Z/ --csv report.csv
+    uv run python tools/analyze_scan_sweep.py scan_sweep_20260829T120000Z/ --verbose --pairs-csv pairs.csv
 """
 
 from __future__ import annotations
@@ -34,6 +43,7 @@ from pathlib import Path
 def _config_key(record: dict) -> tuple:
     return (
         record["prime"],
+        record.get("quiet_drain", True),
         record["resolution"],
         record["mode"],
         record["single_pass_exposure"],
@@ -44,8 +54,9 @@ def _config_key(record: dict) -> tuple:
 
 
 def _config_label(key: tuple) -> str:
-    prime, resolution, mode, single_exp, short_exp, long_exp, me_mode = key
+    prime, quiet_drain, resolution, mode, single_exp, short_exp, long_exp, me_mode = key
     prime_label = "on" if prime else "off"
+    quiet_label = "on" if quiet_drain else "off"
     if mode == "single":
         exp_label = "auto" if single_exp is None else str(single_exp)
         combo = f"single_{exp_label}"
@@ -53,7 +64,7 @@ def _config_label(key: tuple) -> str:
         s = "auto" if short_exp is None else str(short_exp)
         l = "auto" if long_exp is None else str(long_exp)
         combo = f"me_s{s}_l{l}({me_mode})"
-    return f"p-{prime_label}_r{resolution}_{combo}"
+    return f"p-{prime_label}_q-{quiet_label}_r{resolution}_{combo}"
 
 
 def _load_manifest(sweep_dir: Path) -> list[dict]:
@@ -84,11 +95,25 @@ def _phase_correlate_shift(a, b) -> tuple[float, float]:
 
 
 @dataclass
+class PairShift:
+    repeat_a: int
+    repeat_b: int
+    dx: float
+    dy: float
+    magnitude: float
+
+
+@dataclass
 class GroupResult:
     label: str
     n_images: int
     n_errors: int
     n_pairs: int
+    pairs: list[PairShift]
+    mean_dx: float | None
+    mean_dy: float | None
+    max_abs_dx: float | None
+    max_abs_dy: float | None
     mean_shift: float | None
     max_shift: float | None
     mean_clip_fraction: float | None
@@ -103,34 +128,49 @@ def _analyze_group(sweep_dir: Path, key: tuple, records: list[dict]) -> GroupRes
     clip_fractions = [r["clip_fraction"] for r in ok_records if r.get("clip_fraction") is not None]
     mean_clip = sum(clip_fractions) / len(clip_fractions) if clip_fractions else None
 
-    images = []
+    loaded = []
     for r in ok_records:
         img = cv2.imread(str(sweep_dir / r["filename"]), cv2.IMREAD_GRAYSCALE)
         if img is not None:
-            images.append(img)
+            loaded.append((r["repeat_index"], img))
 
-    shifts: list[float] = []
-    for a, b in pairwise(images):
+    pairs: list[PairShift] = []
+    for (rep_a, a), (rep_b, b) in pairwise(loaded):
         if a.shape != b.shape:
             continue
         dx, dy = _phase_correlate_shift(a, b)
-        shifts.append((dx * dx + dy * dy) ** 0.5)
+        pairs.append(PairShift(repeat_a=rep_a, repeat_b=rep_b, dx=dx, dy=dy, magnitude=(dx * dx + dy * dy) ** 0.5))
+
+    magnitudes = [p.magnitude for p in pairs]
+    dxs = [p.dx for p in pairs]
+    dys = [p.dy for p in pairs]
 
     return GroupResult(
         label=label,
         n_images=len(ok_records),
         n_errors=len(errors),
-        n_pairs=len(shifts),
-        mean_shift=(sum(shifts) / len(shifts)) if shifts else None,
-        max_shift=max(shifts) if shifts else None,
+        n_pairs=len(pairs),
+        pairs=pairs,
+        mean_dx=(sum(dxs) / len(dxs)) if dxs else None,
+        mean_dy=(sum(dys) / len(dys)) if dys else None,
+        max_abs_dx=max((abs(v) for v in dxs), default=None),
+        max_abs_dy=max((abs(v) for v in dys), default=None),
+        mean_shift=(sum(magnitudes) / len(magnitudes)) if magnitudes else None,
+        max_shift=max(magnitudes) if magnitudes else None,
         mean_clip_fraction=mean_clip,
     )
+
+
+def _fmt(v: float | None, digits: int = 2) -> str:
+    return f"{v:.{digits}f}" if v is not None else "n/a"
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("sweep_dir", type=Path)
-    parser.add_argument("--csv", type=Path, default=None, help="Also write the table to this CSV path")
+    parser.add_argument("--csv", type=Path, default=None, help="Also write the per-config summary table to this CSV path")
+    parser.add_argument("--pairs-csv", type=Path, default=None, help="Also write one row per individual repeat-pair (dx, dy, magnitude) to this CSV path")
+    parser.add_argument("--verbose", action="store_true", help="Also print each config's raw per-pair shifts")
     args = parser.parse_args(argv)
 
     records = _load_manifest(args.sweep_dir)
@@ -145,22 +185,46 @@ def main(argv: list[str] | None = None) -> int:
     results = [_analyze_group(args.sweep_dir, key, recs) for key, recs in groups.items()]
     results.sort(key=lambda g: (g.max_shift is None, -(g.max_shift or 0.0)))
 
-    header = f"{'config':45} {'n':>3} {'err':>3} {'pairs':>5} {'mean_shift_px':>13} {'max_shift_px':>12} {'mean_clip':>10}"
+    header = (
+        f"{'config':50} {'n':>3} {'err':>3} {'pairs':>5} "
+        f"{'mean_dx':>8} {'mean_dy':>8} {'mean_shift':>10} {'max_shift':>10} {'mean_clip':>10}"
+    )
     print(header)
     print("-" * len(header))
     for g in results:
-        mean_shift = f"{g.mean_shift:.2f}" if g.mean_shift is not None else "n/a"
-        max_shift = f"{g.max_shift:.2f}" if g.max_shift is not None else "n/a"
-        mean_clip = f"{g.mean_clip_fraction:.4f}" if g.mean_clip_fraction is not None else "n/a"
-        print(f"{g.label:45} {g.n_images:>3} {g.n_errors:>3} {g.n_pairs:>5} {mean_shift:>13} {max_shift:>12} {mean_clip:>10}")
+        print(
+            f"{g.label:50} {g.n_images:>3} {g.n_errors:>3} {g.n_pairs:>5} "
+            f"{_fmt(g.mean_dx):>8} {_fmt(g.mean_dy):>8} {_fmt(g.mean_shift):>10} "
+            f"{_fmt(g.max_shift):>10} {_fmt(g.mean_clip_fraction, 4):>10}"
+        )
+        if args.verbose:
+            for p in g.pairs:
+                print(f"    repeat {p.repeat_a}->{p.repeat_b}: dx={p.dx:.2f} dy={p.dy:.2f} |shift|={p.magnitude:.2f}")
 
     if args.csv is not None:
         with args.csv.open("w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f)
-            writer.writerow(["config", "n_images", "n_errors", "n_pairs", "mean_shift_px", "max_shift_px", "mean_clip_fraction"])
+            writer.writerow([
+                "config", "n_images", "n_errors", "n_pairs",
+                "mean_dx", "mean_dy", "max_abs_dx", "max_abs_dy",
+                "mean_shift_px", "max_shift_px", "mean_clip_fraction",
+            ])
             for g in results:
-                writer.writerow([g.label, g.n_images, g.n_errors, g.n_pairs, g.mean_shift, g.max_shift, g.mean_clip_fraction])
+                writer.writerow([
+                    g.label, g.n_images, g.n_errors, g.n_pairs,
+                    g.mean_dx, g.mean_dy, g.max_abs_dx, g.max_abs_dy,
+                    g.mean_shift, g.max_shift, g.mean_clip_fraction,
+                ])
         print(f"\nWrote {args.csv}")
+
+    if args.pairs_csv is not None:
+        with args.pairs_csv.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(["config", "repeat_a", "repeat_b", "dx", "dy", "magnitude"])
+            for g in results:
+                for p in g.pairs:
+                    writer.writerow([g.label, p.repeat_a, p.repeat_b, p.dx, p.dy, p.magnitude])
+        print(f"Wrote {args.pairs_csv}")
 
     return 0
 

--- a/tools/analyze_scan_sweep.py
+++ b/tools/analyze_scan_sweep.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Analyze a tools/scan_sweep.py output directory: pixel-shift drift + exposure clip.
+
+Groups sweep_manifest.jsonl records by config (priming, resolution, mode,
+exposure), and for every config scanned more than once, phase-correlates
+consecutive repeats' PNGs to estimate pixel-shift (dx, dy) between them —
+this is the "how much did the image move between scans" measurement. Reports
+alongside each config's mean exposure-clip fraction from the manifest (no
+precision lost — those stats were computed from the raw 16-bit scan, before
+the PNG's 8-bit conversion).
+
+Does not modify anything; pure read-only analysis. Does not reuse
+pyopticfilm.pass_align.estimate_pass_shift on purpose: that function silently
+returns (0, 0) for shifts above a ~2% guard, which would hide exactly the
+kind of large drift (e.g. priming on/off) this tool exists to surface.
+
+Usage (from repo root)::
+
+    uv run python tools/analyze_scan_sweep.py scan_sweep_20260829T120000Z/
+    uv run python tools/analyze_scan_sweep.py scan_sweep_20260829T120000Z/ --csv report.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from dataclasses import dataclass
+from itertools import pairwise
+from pathlib import Path
+
+
+def _config_key(record: dict) -> tuple:
+    return (
+        record["prime"],
+        record["resolution"],
+        record["mode"],
+        record["single_pass_exposure"],
+        record["me_short_exposure"],
+        record["me_long_exposure"],
+        record["me_exposure_mode"],
+    )
+
+
+def _config_label(key: tuple) -> str:
+    prime, resolution, mode, single_exp, short_exp, long_exp, me_mode = key
+    prime_label = "on" if prime else "off"
+    if mode == "single":
+        exp_label = "auto" if single_exp is None else str(single_exp)
+        combo = f"single_{exp_label}"
+    else:
+        s = "auto" if short_exp is None else str(short_exp)
+        l = "auto" if long_exp is None else str(long_exp)
+        combo = f"me_s{s}_l{l}({me_mode})"
+    return f"p-{prime_label}_r{resolution}_{combo}"
+
+
+def _load_manifest(sweep_dir: Path) -> list[dict]:
+    manifest_path = sweep_dir / "sweep_manifest.jsonl"
+    if not manifest_path.exists():
+        raise SystemExit(f"No sweep_manifest.jsonl in {sweep_dir}")
+    records = []
+    with manifest_path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+    return records
+
+
+def _phase_correlate_shift(a, b) -> tuple[float, float]:
+    """(dx, dy) via Hanning-windowed FFT phase correlation. No shift guard —
+    this tool exists specifically to see large drift, not suppress it."""
+    import cv2
+    import numpy as np
+
+    a = a.astype(np.float32)
+    b = b.astype(np.float32)
+    h, w = a.shape[:2]
+    win = cv2.createHanningWindow((w, h), cv2.CV_32F)
+    (dx, dy), _response = cv2.phaseCorrelate(a, b, win)
+    return float(dx), float(dy)
+
+
+@dataclass
+class GroupResult:
+    label: str
+    n_images: int
+    n_errors: int
+    n_pairs: int
+    mean_shift: float | None
+    max_shift: float | None
+    mean_clip_fraction: float | None
+
+
+def _analyze_group(sweep_dir: Path, key: tuple, records: list[dict]) -> GroupResult:
+    import cv2
+
+    label = _config_label(key)
+    errors = [r for r in records if r.get("error")]
+    ok_records = sorted((r for r in records if not r.get("error")), key=lambda r: r["repeat_index"])
+    clip_fractions = [r["clip_fraction"] for r in ok_records if r.get("clip_fraction") is not None]
+    mean_clip = sum(clip_fractions) / len(clip_fractions) if clip_fractions else None
+
+    images = []
+    for r in ok_records:
+        img = cv2.imread(str(sweep_dir / r["filename"]), cv2.IMREAD_GRAYSCALE)
+        if img is not None:
+            images.append(img)
+
+    shifts: list[float] = []
+    for a, b in pairwise(images):
+        if a.shape != b.shape:
+            continue
+        dx, dy = _phase_correlate_shift(a, b)
+        shifts.append((dx * dx + dy * dy) ** 0.5)
+
+    return GroupResult(
+        label=label,
+        n_images=len(ok_records),
+        n_errors=len(errors),
+        n_pairs=len(shifts),
+        mean_shift=(sum(shifts) / len(shifts)) if shifts else None,
+        max_shift=max(shifts) if shifts else None,
+        mean_clip_fraction=mean_clip,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("sweep_dir", type=Path)
+    parser.add_argument("--csv", type=Path, default=None, help="Also write the table to this CSV path")
+    args = parser.parse_args(argv)
+
+    records = _load_manifest(args.sweep_dir)
+    if not records:
+        print("Manifest is empty.")
+        return 0
+
+    groups: dict[tuple, list[dict]] = {}
+    for r in records:
+        groups.setdefault(_config_key(r), []).append(r)
+
+    results = [_analyze_group(args.sweep_dir, key, recs) for key, recs in groups.items()]
+    results.sort(key=lambda g: (g.max_shift is None, -(g.max_shift or 0.0)))
+
+    header = f"{'config':45} {'n':>3} {'err':>3} {'pairs':>5} {'mean_shift_px':>13} {'max_shift_px':>12} {'mean_clip':>10}"
+    print(header)
+    print("-" * len(header))
+    for g in results:
+        mean_shift = f"{g.mean_shift:.2f}" if g.mean_shift is not None else "n/a"
+        max_shift = f"{g.max_shift:.2f}" if g.max_shift is not None else "n/a"
+        mean_clip = f"{g.mean_clip_fraction:.4f}" if g.mean_clip_fraction is not None else "n/a"
+        print(f"{g.label:45} {g.n_images:>3} {g.n_errors:>3} {g.n_pairs:>5} {mean_shift:>13} {max_shift:>12} {mean_clip:>10}")
+
+    if args.csv is not None:
+        with args.csv.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(["config", "n_images", "n_errors", "n_pairs", "mean_shift_px", "max_shift_px", "mean_clip_fraction"])
+            for g in results:
+                writer.writerow([g.label, g.n_images, g.n_errors, g.n_pairs, g.mean_shift, g.max_shift, g.mean_clip_fraction])
+        print(f"\nWrote {args.csv}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/analyze_scan_sweep.py
+++ b/tools/analyze_scan_sweep.py
@@ -44,6 +44,7 @@ def _config_key(record: dict) -> tuple:
     return (
         record["prime"],
         record.get("quiet_drain", True),
+        record.get("feed_slope_slow", False),
         record["resolution"],
         record["mode"],
         record["single_pass_exposure"],
@@ -54,9 +55,10 @@ def _config_key(record: dict) -> tuple:
 
 
 def _config_label(key: tuple) -> str:
-    prime, quiet_drain, resolution, mode, single_exp, short_exp, long_exp, me_mode = key
+    prime, quiet_drain, feed_slope_slow, resolution, mode, single_exp, short_exp, long_exp, me_mode = key
     prime_label = "on" if prime else "off"
     quiet_label = "on" if quiet_drain else "off"
+    slope_label = "slow" if feed_slope_slow else "fast"
     if mode == "single":
         exp_label = "auto" if single_exp is None else str(single_exp)
         combo = f"single_{exp_label}"
@@ -64,7 +66,7 @@ def _config_label(key: tuple) -> str:
         s = "auto" if short_exp is None else str(short_exp)
         l = "auto" if long_exp is None else str(long_exp)
         combo = f"me_s{s}_l{l}({me_mode})"
-    return f"p-{prime_label}_q-{quiet_label}_r{resolution}_{combo}"
+    return f"p-{prime_label}_q-{quiet_label}_f-{slope_label}_r{resolution}_{combo}"
 
 
 def _load_manifest(sweep_dir: Path) -> list[dict]:
@@ -96,6 +98,8 @@ def _phase_correlate_shift(a, b) -> tuple[float, float]:
 
 @dataclass
 class PairShift:
+    index_a: int
+    index_b: int
     repeat_a: int
     repeat_b: int
     dx: float
@@ -124,7 +128,11 @@ def _analyze_group(sweep_dir: Path, key: tuple, records: list[dict]) -> GroupRes
 
     label = _config_label(key)
     errors = [r for r in records if r.get("error")]
-    ok_records = sorted((r for r in records if not r.get("error")), key=lambda r: r["repeat_index"])
+    # Sort by manifest `index` (true execution order), not `repeat_index`:
+    # with --order shuffled, repeat_index no longer reflects when a scan
+    # actually ran, so pairing by it would compare non-adjacent scans and
+    # sometimes even walk backwards in time.
+    ok_records = sorted((r for r in records if not r.get("error")), key=lambda r: r["index"])
     clip_fractions = [r["clip_fraction"] for r in ok_records if r.get("clip_fraction") is not None]
     mean_clip = sum(clip_fractions) / len(clip_fractions) if clip_fractions else None
 
@@ -132,14 +140,24 @@ def _analyze_group(sweep_dir: Path, key: tuple, records: list[dict]) -> GroupRes
     for r in ok_records:
         img = cv2.imread(str(sweep_dir / r["filename"]), cv2.IMREAD_GRAYSCALE)
         if img is not None:
-            loaded.append((r["repeat_index"], img))
+            loaded.append((r["index"], r["repeat_index"], img))
 
     pairs: list[PairShift] = []
-    for (rep_a, a), (rep_b, b) in pairwise(loaded):
+    for (idx_a, rep_a, a), (idx_b, rep_b, b) in pairwise(loaded):
         if a.shape != b.shape:
             continue
         dx, dy = _phase_correlate_shift(a, b)
-        pairs.append(PairShift(repeat_a=rep_a, repeat_b=rep_b, dx=dx, dy=dy, magnitude=(dx * dx + dy * dy) ** 0.5))
+        pairs.append(
+            PairShift(
+                index_a=idx_a,
+                index_b=idx_b,
+                repeat_a=rep_a,
+                repeat_b=rep_b,
+                dx=dx,
+                dy=dy,
+                magnitude=(dx * dx + dy * dy) ** 0.5,
+            )
+        )
 
     magnitudes = [p.magnitude for p in pairs]
     dxs = [p.dx for p in pairs]
@@ -199,7 +217,10 @@ def main(argv: list[str] | None = None) -> int:
         )
         if args.verbose:
             for p in g.pairs:
-                print(f"    repeat {p.repeat_a}->{p.repeat_b}: dx={p.dx:.2f} dy={p.dy:.2f} |shift|={p.magnitude:.2f}")
+                print(
+                    f"    scan idx {p.index_a} (rep {p.repeat_a}) -> idx {p.index_b} (rep {p.repeat_b}): "
+                    f"dx={p.dx:.2f} dy={p.dy:.2f} |shift|={p.magnitude:.2f}"
+                )
 
     if args.csv is not None:
         with args.csv.open("w", newline="", encoding="utf-8") as f:
@@ -220,10 +241,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.pairs_csv is not None:
         with args.pairs_csv.open("w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f)
-            writer.writerow(["config", "repeat_a", "repeat_b", "dx", "dy", "magnitude"])
+            writer.writerow(["config", "index_a", "index_b", "repeat_a", "repeat_b", "dx", "dy", "magnitude"])
             for g in results:
                 for p in g.pairs:
-                    writer.writerow([g.label, p.repeat_a, p.repeat_b, p.dx, p.dy, p.magnitude])
+                    writer.writerow([g.label, p.index_a, p.index_b, p.repeat_a, p.repeat_b, p.dx, p.dy, p.magnitude])
         print(f"Wrote {args.pairs_csv}")
 
     return 0

--- a/tools/scan_sweep.py
+++ b/tools/scan_sweep.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""Sweep GL128 crop scans across resolution / exposure / priming for analysis.
+"""Sweep GL128 crop scans across resolution / exposure / priming / quiet-drain for analysis.
 
 Built to investigate the jittery 7200 dpi scans and scan-to-scan image
 movement that GL128 priming is a rough workaround for. Runs a grid of real
@@ -23,12 +23,18 @@ in that *same* session is a no-op. So each priming condition here gets its
 own fresh ``Scanner.open()`` ... ``close()`` bracket — comparing "on" vs
 "off" is only meaningful across separate sessions, never within one.
 
+``--quiet-drain`` (Adaptive quiet USB drain, ``asic.image_usb_pace_s``) has
+no such constraint — it's a plain per-scan attribute, toggled fresh before
+every scan regardless of session.
+
 Usage (from repo root)::
 
     uv run python tools/scan_sweep.py --dry-run
     uv run python tools/scan_sweep.py --resolutions 1200,3600,7200 --repeat 3
     uv run python tools/scan_sweep.py --mode me --me-long-exposures auto,60000,90000
     uv run python tools/scan_sweep.py --resolutions 7200 --prime off --repeat 5 --yes
+    uv run python tools/scan_sweep.py --resolutions 1200,3600,7200 --prime both \\
+        --quiet-drain both --repeat 8 --order shuffled --seed 1 --max-scans 300 --yes
 """
 
 from __future__ import annotations
@@ -49,6 +55,7 @@ CLIP_THRESHOLD = 64000
 @dataclass(frozen=True)
 class ScanSpec:
     prime: bool
+    quiet_drain: bool
     resolution: int
     mode: str  # "single" or "me"
     single_pass_exposure: int | None
@@ -68,7 +75,8 @@ class ScanSpec:
 
     def filename(self, index: int) -> str:
         prime_label = "on" if self.prime else "off"
-        return f"{index:04d}_p-{prime_label}_r{self.resolution}_{self.combo_label}_n{self.repeat_index}.png"
+        quiet_label = "on" if self.quiet_drain else "off"
+        return f"{index:04d}_p-{prime_label}_q-{quiet_label}_r{self.resolution}_{self.combo_label}_n{self.repeat_index}.png"
 
 
 def _parse_int_list_or_auto(raw: str) -> list[int | None]:
@@ -111,35 +119,38 @@ def _build_group_specs(
     me_exposure_mode: str,
     repeat: int,
     prime: bool,
+    quiet_drain_values: list[bool],
     order: str,
     seed: int,
 ) -> list[ScanSpec]:
     specs: list[ScanSpec] = []
     modes = ["single", "me"] if mode == "both" else [mode]
     for resolution in resolutions:
-        for m in modes:
-            if m == "single":
-                combos: list[tuple[int | None, int | None, int | None]] = [
-                    (v, None, None) for v in single_exposures
-                ]
-            else:
-                combos = [
-                    (None, s, l) for s in me_short_exposures for l in me_long_exposures
-                ]
-            for single_v, short_v, long_v in combos:
-                for rep in range(1, repeat + 1):
-                    specs.append(
-                        ScanSpec(
-                            prime=prime,
-                            resolution=resolution,
-                            mode=m,
-                            single_pass_exposure=single_v,
-                            me_short_exposure=short_v,
-                            me_long_exposure=long_v,
-                            me_exposure_mode=me_exposure_mode,
-                            repeat_index=rep,
+        for quiet_drain in quiet_drain_values:
+            for m in modes:
+                if m == "single":
+                    combos: list[tuple[int | None, int | None, int | None]] = [
+                        (v, None, None) for v in single_exposures
+                    ]
+                else:
+                    combos = [
+                        (None, s, l) for s in me_short_exposures for l in me_long_exposures
+                    ]
+                for single_v, short_v, long_v in combos:
+                    for rep in range(1, repeat + 1):
+                        specs.append(
+                            ScanSpec(
+                                prime=prime,
+                                quiet_drain=quiet_drain,
+                                resolution=resolution,
+                                mode=m,
+                                single_pass_exposure=single_v,
+                                me_short_exposure=short_v,
+                                me_long_exposure=long_v,
+                                me_exposure_mode=me_exposure_mode,
+                                repeat_index=rep,
+                            )
                         )
-                    )
     if order == "shuffled":
         random.Random(seed).shuffle(specs)
     return specs
@@ -182,6 +193,7 @@ def _run_one(scanner, spec: ScanSpec, index: int, area, out_dir: Path, preview_m
         "timestamp": datetime.now(UTC).isoformat(),
         "filename": filename,
         "prime": spec.prime,
+        "quiet_drain": spec.quiet_drain,
         "resolution": spec.resolution,
         "mode": spec.mode,
         "single_pass_exposure": spec.single_pass_exposure,
@@ -198,6 +210,9 @@ def _run_one(scanner, spec: ScanSpec, index: int, area, out_dir: Path, preview_m
         "error": None,
     }
     try:
+        from pyopticfilm.scan.session_gl128 import IMAGE_USB_PACE_S
+
+        scanner._asic.image_usb_pace_s = IMAGE_USB_PACE_S if spec.quiet_drain else 0.0
         image = scanner.scan(
             resolution=spec.resolution,
             mode="color",
@@ -240,7 +255,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--me-long-exposures", default="auto", help="Comma list of 'auto' or int (ME long exposure)")
     parser.add_argument("--me-exposure-mode", choices=["adaptive", "fixed"], default="adaptive", help="Only matters when --me-long-exposures includes 'auto'")
     parser.add_argument("--prime", choices=["on", "off", "both"], default="both")
-    parser.add_argument("--repeat", type=int, default=3, help="Repeats per (prime, resolution, exposure combo)")
+    parser.add_argument("--quiet-drain", choices=["on", "off", "both"], default="on", help="Adaptive quiet USB drain (asic.image_usb_pace_s) — default 'on' keeps today's default behavior; unlike --prime this needs no fresh session")
+    parser.add_argument("--repeat", type=int, default=3, help="Repeats per (prime, quiet-drain, resolution, exposure combo)")
     parser.add_argument("--order", choices=["sequential", "shuffled"], default="sequential", help="Shuffling is scoped within one priming condition, never across")
     parser.add_argument("--seed", type=int, default=0, help="RNG seed for --order shuffled")
     parser.add_argument("--no-apply-calib", action="store_true")
@@ -264,6 +280,7 @@ def main(argv: list[str] | None = None) -> int:
     me_long_exposures = _parse_int_list_or_auto(args.me_long_exposures)
 
     prime_conditions = {"on": [True], "off": [False], "both": [True, False]}[args.prime]
+    quiet_drain_values = {"on": [True], "off": [False], "both": [True, False]}[args.quiet_drain]
     groups = {
         p: _build_group_specs(
             resolutions=resolutions,
@@ -274,6 +291,7 @@ def main(argv: list[str] | None = None) -> int:
             me_exposure_mode=args.me_exposure_mode,
             repeat=args.repeat,
             prime=p,
+            quiet_drain_values=quiet_drain_values,
             order=args.order,
             seed=args.seed,
         )
@@ -281,7 +299,10 @@ def main(argv: list[str] | None = None) -> int:
     }
     total = sum(len(v) for v in groups.values())
 
-    print(f"Planned sweep: {total} scans across {len(prime_conditions)} priming condition(s), crop={crop}")
+    print(
+        f"Planned sweep: {total} scans across {len(prime_conditions)} priming "
+        f"condition(s) x {len(quiet_drain_values)} quiet-drain condition(s), crop={crop}"
+    )
     for p in prime_conditions:
         specs = groups[p]
         print(f"  prime={p}: {len(specs)} scans, e.g. {[s.filename(i) for i, s in enumerate(specs[:3], 1)]}")

--- a/tools/scan_sweep.py
+++ b/tools/scan_sweep.py
@@ -1,0 +1,340 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Sweep GL128 crop scans across resolution / exposure / priming for analysis.
+
+Built to investigate the jittery 7200 dpi scans and scan-to-scan image
+movement that GL128 priming is a rough workaround for. Runs a grid of real
+crop scans on real hardware (default a small middle square — aim ``--crop``
+at real detail on your mounted negative so pixel-shift correlation has a
+signal to lock onto) and saves:
+
+* one labeled PNG per scan in ``--out`` (or an auto-timestamped directory)
+* ``sweep_manifest.jsonl`` in the same directory: one JSON record per scan
+  with the exact parameters used, raw-16-bit mean/max/clip stats (computed
+  *before* the 8-bit PNG conversion, so exposure-clip analysis doesn't lose
+  precision), duration, and any error.
+
+Follow up with ``tools/analyze_scan_sweep.py <out-dir>`` to get a pixel-shift
+(drift) and exposure-clip report.
+
+IMPORTANT — priming and ``--prime both``: ``Scanner._gl128_primed`` is a
+one-shot flag for the life of a ``Scanner`` object. Once anything in a
+session primes (explicitly or naturally), passing ``gl128_prime=False`` later
+in that *same* session is a no-op. So each priming condition here gets its
+own fresh ``Scanner.open()`` ... ``close()`` bracket — comparing "on" vs
+"off" is only meaningful across separate sessions, never within one.
+
+Usage (from repo root)::
+
+    uv run python tools/scan_sweep.py --dry-run
+    uv run python tools/scan_sweep.py --resolutions 1200,3600,7200 --repeat 3
+    uv run python tools/scan_sweep.py --mode me --me-long-exposures auto,60000,90000
+    uv run python tools/scan_sweep.py --resolutions 7200 --prime off --repeat 5 --yes
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+#: Any channel at/above this (of 65535) counts as "clipped" for clip_fraction.
+CLIP_THRESHOLD = 64000
+
+
+@dataclass(frozen=True)
+class ScanSpec:
+    prime: bool
+    resolution: int
+    mode: str  # "single" or "me"
+    single_pass_exposure: int | None
+    me_short_exposure: int | None
+    me_long_exposure: int | None
+    me_exposure_mode: str
+    repeat_index: int
+
+    @property
+    def combo_label(self) -> str:
+        if self.mode == "single":
+            val = "auto" if self.single_pass_exposure is None else str(self.single_pass_exposure)
+            return f"single_{val}"
+        short = "auto" if self.me_short_exposure is None else str(self.me_short_exposure)
+        long_ = "auto" if self.me_long_exposure is None else str(self.me_long_exposure)
+        return f"me_s{short}_l{long_}"
+
+    def filename(self, index: int) -> str:
+        prime_label = "on" if self.prime else "off"
+        return f"{index:04d}_p-{prime_label}_r{self.resolution}_{self.combo_label}_n{self.repeat_index}.png"
+
+
+def _parse_int_list_or_auto(raw: str) -> list[int | None]:
+    values: list[int | None] = []
+    for part in raw.split(","):
+        part = part.strip().lower()
+        if not part:
+            continue
+        if part == "auto":
+            values.append(None)
+            continue
+        try:
+            values.append(int(part))
+        except ValueError:
+            raise SystemExit(f"Expected 'auto' or an integer, got {part!r} in {raw!r}") from None
+    if not values:
+        raise SystemExit(f"Expected at least one value or 'auto', got {raw!r}")
+    return values
+
+
+def _parse_crop(raw: str) -> tuple[float, float, float, float]:
+    parts_raw = raw.split(",")
+    if len(parts_raw) != 4:
+        raise SystemExit(f"--crop needs 4 comma-separated floats x1,y1,x2,y2, got {raw!r}")
+    try:
+        parts = [float(v.strip()) for v in parts_raw]
+    except ValueError:
+        raise SystemExit(f"--crop values must be floats, got {raw!r}") from None
+    x1, y1, x2, y2 = parts
+    return x1, y1, x2, y2
+
+
+def _build_group_specs(
+    *,
+    resolutions: list[int],
+    mode: str,
+    single_exposures: list[int | None],
+    me_short_exposures: list[int | None],
+    me_long_exposures: list[int | None],
+    me_exposure_mode: str,
+    repeat: int,
+    prime: bool,
+    order: str,
+    seed: int,
+) -> list[ScanSpec]:
+    specs: list[ScanSpec] = []
+    modes = ["single", "me"] if mode == "both" else [mode]
+    for resolution in resolutions:
+        for m in modes:
+            if m == "single":
+                combos: list[tuple[int | None, int | None, int | None]] = [
+                    (v, None, None) for v in single_exposures
+                ]
+            else:
+                combos = [
+                    (None, s, l) for s in me_short_exposures for l in me_long_exposures
+                ]
+            for single_v, short_v, long_v in combos:
+                for rep in range(1, repeat + 1):
+                    specs.append(
+                        ScanSpec(
+                            prime=prime,
+                            resolution=resolution,
+                            mode=m,
+                            single_pass_exposure=single_v,
+                            me_short_exposure=short_v,
+                            me_long_exposure=long_v,
+                            me_exposure_mode=me_exposure_mode,
+                            repeat_index=rep,
+                        )
+                    )
+    if order == "shuffled":
+        random.Random(seed).shuffle(specs)
+    return specs
+
+
+def _to_u8(rgb, *, mode: str):
+    """16-bit RGB -> 8-bit preview. ``linear`` keeps brightness comparable
+    across the whole sweep (needed to *see* clipping); ``auto`` is a 1-99%
+    per-image percentile stretch (nicer to eyeball, not brightness-comparable
+    across scans) — mirrors tools/scanlab/preview.py::auto_level_u8, kept as
+    an inline copy here to avoid a fragile cross-tool import path.
+    """
+    import numpy as np
+
+    if mode == "linear":
+        return (rgb >> 8).astype(np.uint8)
+    u8 = np.empty(rgb.shape[:2] + (rgb.shape[2],), dtype=np.uint8)
+    probe = rgb[::8, ::8] if min(rgb.shape[:2]) >= 32 else rgb
+    for c in range(rgb.shape[2]):
+        lo, hi = np.percentile(probe[:, :, c].astype(np.float32), (1.0, 99.0))
+        plane = rgb[:, :, c].astype(np.float32)
+        if hi <= lo:
+            u8[:, :, c] = 0
+        else:
+            u8[:, :, c] = np.clip((plane - lo) * (255.0 / (hi - lo)), 0, 255).astype(np.uint8)
+    return u8
+
+
+def _save_png(path: Path, rgb_u8) -> None:
+    import cv2
+
+    cv2.imwrite(str(path), cv2.cvtColor(rgb_u8, cv2.COLOR_RGB2BGR))
+
+
+def _run_one(scanner, spec: ScanSpec, index: int, area, out_dir: Path, preview_mode: str, apply_calib: bool) -> dict:
+    t0 = time.monotonic()
+    filename = spec.filename(index)
+    record: dict = {
+        "index": index,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "filename": filename,
+        "prime": spec.prime,
+        "resolution": spec.resolution,
+        "mode": spec.mode,
+        "single_pass_exposure": spec.single_pass_exposure,
+        "me_short_exposure": spec.me_short_exposure,
+        "me_long_exposure": spec.me_long_exposure,
+        "me_exposure_mode": spec.me_exposure_mode,
+        "repeat_index": spec.repeat_index,
+        "crop": list(area),
+        "width": None,
+        "height": None,
+        "mean_rgb": None,
+        "max_rgb": None,
+        "clip_fraction": None,
+        "error": None,
+    }
+    try:
+        image = scanner.scan(
+            resolution=spec.resolution,
+            mode="color",
+            area=area,
+            apply_calib=apply_calib,
+            multi_exposure=(spec.mode == "me"),
+            single_pass_exposure=spec.single_pass_exposure,
+            me_short_exposure=spec.me_short_exposure,
+            me_long_exposure=spec.me_long_exposure,
+            me_exposure_mode=spec.me_exposure_mode,
+            gl128_prime=spec.prime,
+        )
+        rgb = image.rgb
+        record["width"] = int(rgb.shape[1])
+        record["height"] = int(rgb.shape[0])
+        record["mean_rgb"] = [round(float(rgb[..., c].mean()), 1) for c in range(3)]
+        record["max_rgb"] = [int(rgb[..., c].max()) for c in range(3)]
+        record["clip_fraction"] = round(float((rgb >= CLIP_THRESHOLD).any(axis=-1).mean()), 5)
+        _save_png(out_dir / filename, _to_u8(rgb, mode=preview_mode))
+    except Exception as exc:  # noqa: BLE001
+        record["error"] = f"{type(exc).__name__}: {exc}"
+    record["duration_s"] = round(time.monotonic() - t0, 3)
+    return record
+
+
+def _append_manifest(path: Path, record: dict) -> None:
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record) + "\n")
+        f.flush()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--out", type=Path, default=None, help="Output directory (default: scan_sweep_<UTC timestamp>/)")
+    parser.add_argument("--crop", default="0.45,0.45,0.55,0.55", help="Normalized x1,y1,x2,y2 crop (default a small middle square)")
+    parser.add_argument("--resolutions", default="1200,3600,7200", help="Comma list of DPI values (default 1200,3600,7200)")
+    parser.add_argument("--mode", choices=["single", "me", "both"], default="single")
+    parser.add_argument("--single-exposures", default="auto", help="Comma list of 'auto' or int (single-pass exposure)")
+    parser.add_argument("--me-short-exposures", default="auto", help="Comma list of 'auto' or int (ME short exposure)")
+    parser.add_argument("--me-long-exposures", default="auto", help="Comma list of 'auto' or int (ME long exposure)")
+    parser.add_argument("--me-exposure-mode", choices=["adaptive", "fixed"], default="adaptive", help="Only matters when --me-long-exposures includes 'auto'")
+    parser.add_argument("--prime", choices=["on", "off", "both"], default="both")
+    parser.add_argument("--repeat", type=int, default=3, help="Repeats per (prime, resolution, exposure combo)")
+    parser.add_argument("--order", choices=["sequential", "shuffled"], default="sequential", help="Shuffling is scoped within one priming condition, never across")
+    parser.add_argument("--seed", type=int, default=0, help="RNG seed for --order shuffled")
+    parser.add_argument("--no-apply-calib", action="store_true")
+    parser.add_argument("--preview", choices=["linear", "auto"], default="linear", help="linear (>>8, brightness-comparable) or auto (per-image percentile stretch, for eyeballing only)")
+    parser.add_argument("--max-scans", type=int, default=200, help="Refuse a bigger grid without --force")
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--dry-run", action="store_true", help="Print the planned grid and exit; touches no hardware")
+    parser.add_argument("--yes", action="store_true", help="Skip the interactive confirmation")
+    parser.add_argument("--stop-on-error", action="store_true", help="Abort the whole sweep on the first failed scan instead of logging and continuing")
+    args = parser.parse_args(argv)
+
+    crop = _parse_crop(args.crop)
+    try:
+        resolutions = [int(v.strip()) for v in args.resolutions.split(",") if v.strip()]
+    except ValueError:
+        raise SystemExit(f"--resolutions must be a comma list of integers, got {args.resolutions!r}") from None
+    if not resolutions:
+        raise SystemExit("--resolutions needs at least one value")
+    single_exposures = _parse_int_list_or_auto(args.single_exposures)
+    me_short_exposures = _parse_int_list_or_auto(args.me_short_exposures)
+    me_long_exposures = _parse_int_list_or_auto(args.me_long_exposures)
+
+    prime_conditions = {"on": [True], "off": [False], "both": [True, False]}[args.prime]
+    groups = {
+        p: _build_group_specs(
+            resolutions=resolutions,
+            mode=args.mode,
+            single_exposures=single_exposures,
+            me_short_exposures=me_short_exposures,
+            me_long_exposures=me_long_exposures,
+            me_exposure_mode=args.me_exposure_mode,
+            repeat=args.repeat,
+            prime=p,
+            order=args.order,
+            seed=args.seed,
+        )
+        for p in prime_conditions
+    }
+    total = sum(len(v) for v in groups.values())
+
+    print(f"Planned sweep: {total} scans across {len(prime_conditions)} priming condition(s), crop={crop}")
+    for p in prime_conditions:
+        specs = groups[p]
+        print(f"  prime={p}: {len(specs)} scans, e.g. {[s.filename(i) for i, s in enumerate(specs[:3], 1)]}")
+    if args.dry_run:
+        return 0
+
+    if total > args.max_scans and not args.force:
+        raise SystemExit(f"{total} scans exceeds --max-scans {args.max_scans} (use --force to run anyway)")
+    if not args.yes:
+        reply = input(f"Run {total} scans on real hardware? [y/N] ").strip().lower()
+        if reply != "y":
+            print("Aborted.")
+            return 1
+
+    from pyopticfilm.scanner import Scanner
+
+    out_dir = args.out or Path(f"scan_sweep_{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = out_dir / "sweep_manifest.jsonl"
+    print(f"Writing to {out_dir}/")
+
+    apply_calib = not args.no_apply_calib
+    index = 1
+    for prime in prime_conditions:
+        specs = groups[prime]
+        print(f"\n=== priming condition: {prime} ({len(specs)} scans) ===")
+        scanner = Scanner.open()
+        try:
+            if scanner.model.asic != "GL128":
+                raise SystemExit(f"Expected a GL128 model (8100 V2 / 8200i SE), got {scanner.model.model} ({scanner.model.asic})")
+            scanner.warmup()
+            for spec in specs:
+                print(f"[{index}/{total}] {spec.filename(index)} ...", end=" ", flush=True)
+                record = _run_one(scanner, spec, index, crop, out_dir, args.preview, apply_calib)
+                _append_manifest(manifest_path, record)
+                if record["error"]:
+                    print(f"FAILED: {record['error']}")
+                    if args.stop_on_error:
+                        raise SystemExit(1)
+                else:
+                    print(f"ok ({record['duration_s']}s, clip={record['clip_fraction']:.3f})")
+                index += 1
+        finally:
+            try:
+                scanner.lamp_off()
+            except Exception:  # noqa: BLE001, S110
+                pass
+            scanner.close()
+
+    print(f"\nDone. {index - 1} scans attempted. Manifest: {manifest_path}")
+    print(f"Next: uv run python tools/analyze_scan_sweep.py {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/scan_sweep.py
+++ b/tools/scan_sweep.py
@@ -56,6 +56,7 @@ CLIP_THRESHOLD = 64000
 class ScanSpec:
     prime: bool
     quiet_drain: bool
+    feed_slope_slow: bool
     resolution: int
     mode: str  # "single" or "me"
     single_pass_exposure: int | None
@@ -76,7 +77,11 @@ class ScanSpec:
     def filename(self, index: int) -> str:
         prime_label = "on" if self.prime else "off"
         quiet_label = "on" if self.quiet_drain else "off"
-        return f"{index:04d}_p-{prime_label}_q-{quiet_label}_r{self.resolution}_{self.combo_label}_n{self.repeat_index}.png"
+        slope_label = "slow" if self.feed_slope_slow else "fast"
+        return (
+            f"{index:04d}_p-{prime_label}_q-{quiet_label}_f-{slope_label}_"
+            f"r{self.resolution}_{self.combo_label}_n{self.repeat_index}.png"
+        )
 
 
 def _parse_int_list_or_auto(raw: str) -> list[int | None]:
@@ -120,6 +125,7 @@ def _build_group_specs(
     repeat: int,
     prime: bool,
     quiet_drain_values: list[bool],
+    feed_slope_values: list[bool],
     order: str,
     seed: int,
 ) -> list[ScanSpec]:
@@ -127,30 +133,32 @@ def _build_group_specs(
     modes = ["single", "me"] if mode == "both" else [mode]
     for resolution in resolutions:
         for quiet_drain in quiet_drain_values:
-            for m in modes:
-                if m == "single":
-                    combos: list[tuple[int | None, int | None, int | None]] = [
-                        (v, None, None) for v in single_exposures
-                    ]
-                else:
-                    combos = [
-                        (None, s, l) for s in me_short_exposures for l in me_long_exposures
-                    ]
-                for single_v, short_v, long_v in combos:
-                    for rep in range(1, repeat + 1):
-                        specs.append(
-                            ScanSpec(
-                                prime=prime,
-                                quiet_drain=quiet_drain,
-                                resolution=resolution,
-                                mode=m,
-                                single_pass_exposure=single_v,
-                                me_short_exposure=short_v,
-                                me_long_exposure=long_v,
-                                me_exposure_mode=me_exposure_mode,
-                                repeat_index=rep,
+            for feed_slope_slow in feed_slope_values:
+                for m in modes:
+                    if m == "single":
+                        combos: list[tuple[int | None, int | None, int | None]] = [
+                            (v, None, None) for v in single_exposures
+                        ]
+                    else:
+                        combos = [
+                            (None, s, l) for s in me_short_exposures for l in me_long_exposures
+                        ]
+                    for single_v, short_v, long_v in combos:
+                        for rep in range(1, repeat + 1):
+                            specs.append(
+                                ScanSpec(
+                                    prime=prime,
+                                    quiet_drain=quiet_drain,
+                                    feed_slope_slow=feed_slope_slow,
+                                    resolution=resolution,
+                                    mode=m,
+                                    single_pass_exposure=single_v,
+                                    me_short_exposure=short_v,
+                                    me_long_exposure=long_v,
+                                    me_exposure_mode=me_exposure_mode,
+                                    repeat_index=rep,
+                                )
                             )
-                        )
     if order == "shuffled":
         random.Random(seed).shuffle(specs)
     return specs
@@ -194,6 +202,7 @@ def _run_one(scanner, spec: ScanSpec, index: int, area, out_dir: Path, preview_m
         "filename": filename,
         "prime": spec.prime,
         "quiet_drain": spec.quiet_drain,
+        "feed_slope_slow": spec.feed_slope_slow,
         "resolution": spec.resolution,
         "mode": spec.mode,
         "single_pass_exposure": spec.single_pass_exposure,
@@ -213,6 +222,7 @@ def _run_one(scanner, spec: ScanSpec, index: int, area, out_dir: Path, preview_m
         from pyopticfilm.scan.session_gl128 import IMAGE_USB_PACE_S
 
         scanner._asic.image_usb_pace_s = IMAGE_USB_PACE_S if spec.quiet_drain else 0.0
+        scanner._asic.experimental_feed_slope_slow = spec.feed_slope_slow
         image = scanner.scan(
             resolution=spec.resolution,
             mode="color",
@@ -256,7 +266,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--me-exposure-mode", choices=["adaptive", "fixed"], default="adaptive", help="Only matters when --me-long-exposures includes 'auto'")
     parser.add_argument("--prime", choices=["on", "off", "both"], default="both")
     parser.add_argument("--quiet-drain", choices=["on", "off", "both"], default="on", help="Adaptive quiet USB drain (asic.image_usb_pace_s) — default 'on' keeps today's default behavior; unlike --prime this needs no fresh session")
-    parser.add_argument("--repeat", type=int, default=3, help="Repeats per (prime, quiet-drain, resolution, exposure combo)")
+    parser.add_argument("--feed-slope", choices=["fast", "slow", "both"], default="fast", help="Positioning-feed motor ramp (asic.experimental_feed_slope_slow) — default 'fast' keeps today's (real vendor) behavior; 'slow' A/B tests SLOPE_TABLE_SLOW for feeds instead, to test whether an aggressive ramp is losing steps")
+    parser.add_argument("--repeat", type=int, default=3, help="Repeats per (prime, quiet-drain, feed-slope, resolution, exposure combo)")
     parser.add_argument("--order", choices=["sequential", "shuffled"], default="sequential", help="Shuffling is scoped within one priming condition, never across")
     parser.add_argument("--seed", type=int, default=0, help="RNG seed for --order shuffled")
     parser.add_argument("--no-apply-calib", action="store_true")
@@ -281,6 +292,7 @@ def main(argv: list[str] | None = None) -> int:
 
     prime_conditions = {"on": [True], "off": [False], "both": [True, False]}[args.prime]
     quiet_drain_values = {"on": [True], "off": [False], "both": [True, False]}[args.quiet_drain]
+    feed_slope_values = {"fast": [False], "slow": [True], "both": [False, True]}[args.feed_slope]
     groups = {
         p: _build_group_specs(
             resolutions=resolutions,
@@ -292,6 +304,7 @@ def main(argv: list[str] | None = None) -> int:
             repeat=args.repeat,
             prime=p,
             quiet_drain_values=quiet_drain_values,
+            feed_slope_values=feed_slope_values,
             order=args.order,
             seed=args.seed,
         )
@@ -301,7 +314,8 @@ def main(argv: list[str] | None = None) -> int:
 
     print(
         f"Planned sweep: {total} scans across {len(prime_conditions)} priming "
-        f"condition(s) x {len(quiet_drain_values)} quiet-drain condition(s), crop={crop}"
+        f"condition(s) x {len(quiet_drain_values)} quiet-drain condition(s) x "
+        f"{len(feed_slope_values)} feed-slope condition(s), crop={crop}"
     )
     for p in prime_conditions:
         specs = groups[p]


### PR DESCRIPTION
## Summary

Tooling used to produce the data in #33 (GL128/8100 V2 positioning-jitter
investigation). No behavior changes for normal use — everything here is
either a new standalone `tools/` script or an opt-in, default-`False`
experimental flag on `Gl128`.

- **`tools/scan_sweep.py`** — drives the scanner through a repeatable grid
  of tiny crop scans, varying resolution / exposure / priming / "Adaptive
  quiet drain" / feed-ramp speed, and writes a labeled PNG plus a JSONL
  manifest (raw-16-bit mean/max/clip-fraction) per scan.
- **`tools/analyze_scan_sweep.py`** — offline: phase-correlates repeats
  within each config and reports per-axis (dx/dy) pixel-shift drift and
  clip fraction, worst-first, with `--csv`/`--pairs-csv`/`--verbose` output.
  Doesn't reuse `pass_align.estimate_pass_shift()` on purpose — that
  function silently clamps any shift over ~16px (or 2% of width) to zero,
  which is fine for production ME/IR registration but would hide exactly
  the large drifts (up to ~220px) this tool exists to measure.
- **`Gl128.experimental_feed_slope_slow`** (default `False`) — lets
  positioning feeds use the slow motor ramp instead of the always-fast one,
  for A/B testing whether ramp speed affects Y-axis drift (used by
  `scan_sweep.py --feed-slope`). Tested in #33; did not show a measurable
  effect at n=32, kept as a tool for further testing rather than removed.

Posted the write-up first as #33 rather than bundling conclusions into this
PR, since the investigation itself didn't reach a root-cause fix — this PR
is just the tooling, in case it's useful for someone else to pick up where
that issue leaves off.

## Test plan

- `uv run ruff check .` — clean
- `QT_QPA_PLATFORM=offscreen uv run pytest -q` — 233 passed, 1 skipped
- `tools/scan_sweep.py --dry-run` verified grid/filename generation across
  all sweep dimensions (prime/quiet-drain/feed-slope)
- `tools/analyze_scan_sweep.py` verified against a synthetic manifest with
  known shifts before trusting it on real hardware data
- Real hardware: all numbers in #33 were produced with these two tools
