### PR TITLE
fix(gl128): use the slow motor ramp for the final positioning feed on the 8100 V2

### DIFF
--- a/src/pyopticfilm/asic/gl128.py
+++ b/src/pyopticfilm/asic/gl128.py
@@ -1408,9 +1408,18 @@ class Gl128:
             )
         return int(limit_mm * self.model.feed_steps_per_inch / MM_PER_INCH)
 
-    def _upload_fast_slopes(self) -> None:
-        """Upload the fast motor ramp to both AHB slope windows."""
-        slope = _u16_table_bytes(SLOPE_TABLE_FAST)
+    def _upload_fast_slopes(self, *, use_slow: bool = False) -> None:
+        """Upload the motor ramp to both AHB slope windows.
+
+        2026-08-30: two independent real USB captures of the vendor driver
+        show every positioning feed pair uploading ``SLOPE_TABLE_FAST`` for
+        the first (reference) feed but ``SLOPE_TABLE_SLOW`` for the second
+        (final positioning) feed — exact byte match in both sources, every
+        time. This function previously always used the fast ramp
+        regardless of caller, which produced a real mechanical fault on
+        the 8100 V2 (see the issue this fix closes).
+        """
+        slope = _u16_table_bytes(SLOPE_TABLE_SLOW if use_slow else SLOPE_TABLE_FAST)
         r = self.registers
         self.protocol.write_ahb(r.AHB_SLOPE_SCAN, slope)
         self.protocol.write_ahb(r.AHB_SLOPE_FAST, slope)
@@ -1442,12 +1451,19 @@ class Gl128:
         *,
         timeout_s: float = 30.0,
         require_motion: bool = True,
+        use_slow_slope: bool = False,
     ) -> None:
         """Replay the captured fast-feed recipe (see MOTOR.md).
 
         Does **not** write ``0x0d`` before ``0x0f`` — feeds in the capture start
-        with ``0x0f = 0x01`` alone. Completion is the vendor probe at
-        ``wIndex=0x21`` returning ``0x04``.
+        with ``0x0f = 0x01`` alone. Completion is either the model's vendor
+        probe (``model.feed_probe_index``, SE only — see that attribute's
+        docstring) returning ``0x04``, or the ``0x101`` status register's
+        ``FEEDFSH`` bit (confirmed on both models; the only signal used on
+        the 8100 V2).
+
+        ``use_slow_slope``: pass ``True`` for the final positioning feed —
+        see ``_upload_fast_slopes``'s docstring for the capture evidence.
         """
         steps = max(0, int(steps))
         if steps == 0:
@@ -1461,7 +1477,7 @@ class Gl128:
         self._write_many(setup)
         self.protocol.write_u24(r.REG_FEEDL, steps)
         self._write(r.REG_0x02, r.MTRPWR | r.FASTFED)  # 0x18
-        self._upload_fast_slopes()
+        self._upload_fast_slopes(use_slow=use_slow_slope)
         # This recipe deliberately does not clear the counter, so the probe and
         # FEEDFSH still carry the previous feed's completion. Sample them now so
         # the wait below knows not to believe the first "done" it sees.
@@ -1610,7 +1626,7 @@ class Gl128:
             second,
         )
         self._feed_capture(first, timeout_s=timeout_s / 2, require_motion=True)
-        self._feed_capture(second, timeout_s=timeout_s / 2, require_motion=True)
+        self._feed_capture(second, timeout_s=timeout_s / 2, require_motion=True, use_slow_slope=True)
         end = self.read_status_reliable()
         logger.info("GL128 positioned for scan (status 0x%02x)", end.raw)
         if end.is_at_home:

--- a/src/pyopticfilm/asic/gl128.py
+++ b/src/pyopticfilm/asic/gl128.py
@@ -1411,13 +1411,17 @@ class Gl128:
     def _upload_fast_slopes(self, *, use_slow: bool = False) -> None:
         """Upload the motor ramp to both AHB slope windows.
 
-        2026-08-30: two independent real USB captures of the vendor driver
-        show every positioning feed pair uploading ``SLOPE_TABLE_FAST`` for
-        the first (reference) feed but ``SLOPE_TABLE_SLOW`` for the second
-        (final positioning) feed — exact byte match in both sources, every
-        time. This function previously always used the fast ramp
-        regardless of caller, which produced a real mechanical fault on
-        the 8100 V2 (see the issue this fix closes).
+        2026-08-30: two independent real USB captures of the 8100 V2's
+        vendor driver show every positioning feed pair uploading
+        ``SLOPE_TABLE_FAST`` for the first (reference) feed but
+        ``SLOPE_TABLE_SLOW`` for the second (final positioning) feed —
+        exact byte match in both sources, every time. This function
+        previously always used the fast ramp regardless of caller, which
+        produced a real mechanical fault on the 8100 V2 (see the issue
+        this fix closes). Applying `use_slow` to the second feed is gated
+        per-model (``Model.use_slow_final_positioning_feed`` — see that
+        attribute's docstring) since this evidence is V2-only; SE behavior
+        is unchanged.
         """
         slope = _u16_table_bytes(SLOPE_TABLE_SLOW if use_slow else SLOPE_TABLE_FAST)
         r = self.registers
@@ -1626,7 +1630,8 @@ class Gl128:
             second,
         )
         self._feed_capture(first, timeout_s=timeout_s / 2, require_motion=True)
-        self._feed_capture(second, timeout_s=timeout_s / 2, require_motion=True, use_slow_slope=True)
+        use_slow_second_feed = bool(getattr(self.model, "use_slow_final_positioning_feed", False))
+        self._feed_capture(second, timeout_s=timeout_s / 2, require_motion=True, use_slow_slope=use_slow_second_feed)
         end = self.read_status_reliable()
         logger.info("GL128 positioned for scan (status 0x%02x)", end.raw)
         if end.is_at_home:

--- a/src/pyopticfilm/device/model_8100_v2.py
+++ b/src/pyopticfilm/device/model_8100_v2.py
@@ -103,6 +103,13 @@ class Model8100V2(Model8200iSE):
     # V2 uses feed2=13128 for all scan types (top of TA window), not SE's 13560.
     ladder_feed2_steps: int = 13128
 
+    # Real-hardware fault fix: two independent captures (this repo's own
+    # session, plus the recovered 04_color_7200.pcapng) show the second
+    # (final positioning) feed uses the slow motor ramp, not the fast one
+    # SE defaults to. See Model8200iSE.use_slow_final_positioning_feed's
+    # docstring — not yet independently verified on SE.
+    use_slow_final_positioning_feed: bool = True
+
     def shading_strip_clocks(self, resolution: int, *, dvdset: bool) -> tuple[int, int, int]:
         """Return ``(dummy, clk_a, clk_b)`` for a shading strip.
 

--- a/src/pyopticfilm/device/model_8200i_se.py
+++ b/src/pyopticfilm/device/model_8200i_se.py
@@ -435,6 +435,17 @@ class Model8200iSE:
     #: half a millimetre and together cover the 25.59 mm window.
     feed_to_scan_bottom_steps: int = 20232
 
+    #: Whether the second (final positioning) feed in
+    #: ``position_for_full_frame_scan()`` uploads the slow motor ramp
+    #: instead of the fast one. Verified on the 8100 V2 from two independent
+    #: real captures (see ``Model8100V2``'s override and the linked issue);
+    #: **not independently verified on the SE** — SE hardware has not been
+    #: captured for this specific behavior, even though the raw
+    #: ``SLOPE_TABLE_FAST``/``SLOPE_TABLE_SLOW`` values themselves are
+    #: SE-session-derived. Defaults to the SE's original (unchanged)
+    #: behavior — fast for both feeds — until SE-specific evidence exists.
+    use_slow_final_positioning_feed: bool = False
+
     #: Largest single FEEDL observed in captures; refuse anything larger.
     max_feed_steps: int = 28292
 

--- a/tests/test_gl128_slope_table.py
+++ b/tests/test_gl128_slope_table.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""GL128 motor slope-table selection per feed (2026-08-30 real-hardware fault).
+
+Two independent real captures (a second capture session's files, and the
+original vendor capture ``04_color_7200.pcapng``) show every positioning
+feed pair uploading ``SLOPE_TABLE_FAST`` for the first (reference) feed but
+``SLOPE_TABLE_SLOW`` for the second (final positioning) feed — exact byte
+match in both sources, every time. pyopticfilm previously always used the
+fast ramp for both feeds. See docs/hw-ref/8100v2/PROGRESS.md.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from pyopticfilm.asic.gl128 import Gl128
+from pyopticfilm.device.model_8200i_se import MODEL_8200I_SE
+from pyopticfilm.device.select import create_asic
+from pyopticfilm.device.tables_8200i_se import SLOPE_TABLE_FAST, SLOPE_TABLE_SLOW
+from pyopticfilm.usb.fake import MockScannerTransport
+from pyopticfilm.usb.protocol import GenesysUsbProtocol
+
+
+def _pack(words: tuple[int, ...]) -> bytes:
+    out = bytearray(len(words) * 2)
+    for i, word in enumerate(words):
+        out[2 * i] = word & 0xFF
+        out[2 * i + 1] = (word >> 8) & 0xFF
+    return bytes(out)
+
+
+def test_upload_fast_slopes_default_is_fast():
+    asic = Gl128(MagicMock(), MODEL_8200I_SE)
+    asic._upload_fast_slopes()
+
+    calls = asic.protocol.write_ahb.call_args_list
+    assert len(calls) == 2
+    for call in calls:
+        assert call.args[1] == _pack(SLOPE_TABLE_FAST)
+
+
+def test_upload_fast_slopes_use_slow_uploads_slow_table():
+    asic = Gl128(MagicMock(), MODEL_8200I_SE)
+    asic._upload_fast_slopes(use_slow=True)
+
+    calls = asic.protocol.write_ahb.call_args_list
+    assert len(calls) == 2
+    for call in calls:
+        assert call.args[1] == _pack(SLOPE_TABLE_SLOW)
+
+
+def test_feed_capture_threads_use_slow_slope_through(monkeypatch):
+    import pyopticfilm.asic.gl128 as gl128_mod
+
+    monkeypatch.setattr(gl128_mod.time, "sleep", lambda *_a, **_k: None)
+
+    asic = Gl128(MagicMock(), MODEL_8200I_SE)
+    asic._upload_fast_slopes = MagicMock()
+    asic._feed_done_indicated = MagicMock(return_value=False)
+    asic.read_status_reliable = MagicMock(
+        side_effect=lambda: type("S", (), {"is_at_home": True, "is_motor_enabled": False, "is_feeding_finished": True, "raw": 0})()
+    )
+
+    asic._feed_capture(100, timeout_s=1.0, require_motion=False, use_slow_slope=True)
+    asic._upload_fast_slopes.assert_called_once_with(use_slow=True)
+
+    asic._upload_fast_slopes.reset_mock()
+    asic._feed_capture(100, timeout_s=1.0, require_motion=False, use_slow_slope=False)
+    asic._upload_fast_slopes.assert_called_once_with(use_slow=False)
+
+
+def test_position_for_full_frame_scan_uses_fast_then_slow(monkeypatch):
+    """End-to-end via mock hardware: first feed FAST, second feed SLOW."""
+    usb = MockScannerTransport()
+    protocol = GenesysUsbProtocol(usb)
+    asic = create_asic(protocol, MODEL_8200I_SE)
+    asic._motor_moves_enabled = True
+
+    ahb_writes: list[bytes] = []
+    orig_write_ahb = protocol.write_ahb
+
+    def _tracking_write_ahb(addr, data):
+        r = asic.registers
+        if addr in (r.AHB_SLOPE_SCAN, r.AHB_SLOPE_FAST):
+            ahb_writes.append(bytes(data))
+        return orig_write_ahb(addr, data)
+
+    protocol.write_ahb = _tracking_write_ahb
+
+    asic.home_ready_for_test = True  # no-op marker; mock transport starts at home
+    asic.position_for_full_frame_scan(scan_steps=13704)
+
+    fast = _pack(SLOPE_TABLE_FAST)
+    slow = _pack(SLOPE_TABLE_SLOW)
+    assert len(ahb_writes) == 4  # 2 windows x 2 feeds
+    assert ahb_writes[0] == fast
+    assert ahb_writes[1] == fast
+    assert ahb_writes[2] == slow
+    assert ahb_writes[3] == slow

--- a/tests/test_gl128_slope_table.py
+++ b/tests/test_gl128_slope_table.py
@@ -14,11 +14,26 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from pyopticfilm.asic.gl128 import Gl128
+from pyopticfilm.device.model_8100_v2 import MODEL_8100_V2
 from pyopticfilm.device.model_8200i_se import MODEL_8200I_SE
 from pyopticfilm.device.select import create_asic
 from pyopticfilm.device.tables_8200i_se import SLOPE_TABLE_FAST, SLOPE_TABLE_SLOW
 from pyopticfilm.usb.fake import MockScannerTransport
 from pyopticfilm.usb.protocol import GenesysUsbProtocol
+
+
+def _track_ahb_writes(asic, protocol):
+    ahb_writes: list[bytes] = []
+    orig_write_ahb = protocol.write_ahb
+
+    def _tracking_write_ahb(addr, data):
+        r = asic.registers
+        if addr in (r.AHB_SLOPE_SCAN, r.AHB_SLOPE_FAST):
+            ahb_writes.append(bytes(data))
+        return orig_write_ahb(addr, data)
+
+    protocol.write_ahb = _tracking_write_ahb
+    return ahb_writes
 
 
 def _pack(words: tuple[int, ...]) -> bytes:
@@ -69,26 +84,15 @@ def test_feed_capture_threads_use_slow_slope_through(monkeypatch):
     asic._upload_fast_slopes.assert_called_once_with(use_slow=False)
 
 
-def test_position_for_full_frame_scan_uses_fast_then_slow(monkeypatch):
-    """End-to-end via mock hardware: first feed FAST, second feed SLOW."""
+def test_position_for_full_frame_scan_uses_fast_then_slow_on_v2(monkeypatch):
+    """End-to-end via mock hardware, 8100 V2: first feed FAST, second SLOW."""
     usb = MockScannerTransport()
     protocol = GenesysUsbProtocol(usb)
-    asic = create_asic(protocol, MODEL_8200I_SE)
+    asic = create_asic(protocol, MODEL_8100_V2)
     asic._motor_moves_enabled = True
+    ahb_writes = _track_ahb_writes(asic, protocol)
 
-    ahb_writes: list[bytes] = []
-    orig_write_ahb = protocol.write_ahb
-
-    def _tracking_write_ahb(addr, data):
-        r = asic.registers
-        if addr in (r.AHB_SLOPE_SCAN, r.AHB_SLOPE_FAST):
-            ahb_writes.append(bytes(data))
-        return orig_write_ahb(addr, data)
-
-    protocol.write_ahb = _tracking_write_ahb
-
-    asic.home_ready_for_test = True  # no-op marker; mock transport starts at home
-    asic.position_for_full_frame_scan(scan_steps=13704)
+    asic.position_for_full_frame_scan(scan_steps=13486)
 
     fast = _pack(SLOPE_TABLE_FAST)
     slow = _pack(SLOPE_TABLE_SLOW)
@@ -97,3 +101,23 @@ def test_position_for_full_frame_scan_uses_fast_then_slow(monkeypatch):
     assert ahb_writes[1] == fast
     assert ahb_writes[2] == slow
     assert ahb_writes[3] == slow
+
+
+def test_position_for_full_frame_scan_stays_fast_on_se(monkeypatch):
+    """Regression guard: SE is unaffected by the V2-only slope fix.
+
+    This evidence is V2-only (see Model8200iSE.use_slow_final_positioning_
+    feed's docstring) -- SE must keep using the fast ramp for both feeds,
+    exactly as before this fix, until SE-specific evidence exists.
+    """
+    usb = MockScannerTransport()
+    protocol = GenesysUsbProtocol(usb)
+    asic = create_asic(protocol, MODEL_8200I_SE)
+    asic._motor_moves_enabled = True
+    ahb_writes = _track_ahb_writes(asic, protocol)
+
+    asic.position_for_full_frame_scan(scan_steps=13704)
+
+    fast = _pack(SLOPE_TABLE_FAST)
+    assert len(ahb_writes) == 4
+    assert all(w == fast for w in ahb_writes), "SE must stay fast-fast, not fast-slow"


### PR DESCRIPTION
Fixes #39.

Real 8100 V2 hardware testing found a serious mechanical fault (a high-pitched sound followed by a thunk, consistent with a motor overspeed/hard-stop event) during the carriage's final approach to the scan-start position, immediately before image acquisition. USB capture analysis traced it to `Gl128._upload_fast_slopes()` always uploading the aggressive `SLOPE_TABLE_FAST` motor ramp for both feeds in `position_for_full_frame_scan()`.

Two independent real USB captures of the vendor driver — a second, independently-sourced capture session, and the original vendor capture (`04_color_7200.pcapng`) — both show the *first* (reference) feed uploads `SLOPE_TABLE_FAST`, but the *second* (final positioning) feed uploads `SLOPE_TABLE_SLOW` instead. Exact byte-for-byte match in both sources, every time. pyopticfilm always used the fast ramp for both feeds unconditionally.

**Scoped to the 8100 V2 only, not the shared `Gl128` code path.** `Gl128` is the same ASIC driver class for both the 8100 V2 and the 8200i SE, but every capture behind this fix is V2-only — I don't have SE hardware or SE-specific captures to verify this same fast-then-slow pattern holds there too. The raw `SLOPE_TABLE_FAST`/`SLOPE_TABLE_SLOW` values are SE-session-derived, so it's plausible SE follows the same pattern given shared silicon, but that's not the same as verified — physical transport tolerances can differ between scanner models even sharing an ASIC. Added `Model.use_slow_final_positioning_feed` (default `False`, unchanged SE behavior), overridden to `True` only on `Model8100V2`.

**If you're able to validate this on 8200i SE hardware, it's a one-line change to enable for SE too** — flip `use_slow_final_positioning_feed` to `True` on `Model8200iSE` (or override it per-model as done here) once confirmed. Didn't want to ship an SE behavior change neither of us has verified, given the whole point of this fix is a case where an unverified hardware change caused a real fault.

`Gl128._upload_fast_slopes()` gains a `use_slow` parameter; `_feed_capture()` threads it through; `position_for_full_frame_scan()`'s second feed now reads the per-model flag. The reference feed and `feed()` (the general single-feed API) are unaffected on both models.

Verified clean on real 8100 V2 hardware across 6+ consecutive full scans at 1200/1800/3600/7200dpi after this change, following repeated faults before it under the same test conditions.

## Test plan
- [x] New tests (`test_gl128_slope_table.py`) verify byte-for-byte table selection per model, including an explicit regression guard that SE stays fast-fast
- [x] Full existing suite passes (252 passed, 3 skipped)
- [x] Lint clean
- [x] Verified on real 8100 V2 hardware, repeatedly, at multiple DPIs