### PR TITLE
fix(gl128): default priming off on the 8100 V2 (SE unaffected)

### DIFF
--- a/src/pyopticfilm/device/model_8100_v2.py
+++ b/src/pyopticfilm/device/model_8100_v2.py
@@ -103,6 +103,17 @@ class Model8100V2(Model8200iSE):
     # V2 uses feed2=13128 for all scan types (top of TA window), not SE's 13560.
     ladder_feed2_steps: int = 13128
 
+    # 2026-08-30: real-hardware isolation testing (repeated, 5-for-5 clean
+    # trials at 1200/1800/7200dpi) found the motor slope-table fix
+    # (_upload_fast_slopes' use_slow parameter, gl128.py, see PR #40) resolves
+    # a mechanical fault seen during hardware testing. Priming was off in
+    # every one of those clean trials; priming ON has not yet been separately
+    # re-tested now that the slope table is fixed, so this is a precautionary
+    # default matching what's actually been proven safe on real V2 hardware,
+    # not a claim that priming itself is dangerous. Still fully overridable
+    # via Scanner.scan(gl128_prime=True) or a host's own UI toggle.
+    default_gl128_prime: bool = False
+
     def shading_strip_clocks(self, resolution: int, *, dvdset: bool) -> tuple[int, int, int]:
         """Return ``(dummy, clk_a, clk_b)`` for a shading strip.
 

--- a/src/pyopticfilm/device/model_8200i_se.py
+++ b/src/pyopticfilm/device/model_8200i_se.py
@@ -307,6 +307,17 @@ class Model8200iSE:
     #: PPI below this share the 600 dpi ASIC programming (session 13).
     min_asic_dpi: int = _MIN_ASIC_DPI
 
+    #: Default for ``Scanner.scan(gl128_prime=...)`` when the caller passes
+    #: ``None`` (leaves the choice to the model) rather than an explicit
+    #: ``True``/``False``. SE default: unchanged, prime on. GL128 priming was
+    #: introduced (and its ~30-46px first-pass positioning benefit measured)
+    #: on the 8100 V2 specifically — it has never been independently
+    #: confirmed as needed on SE hardware, so this default is inherited
+    #: assumption, not SE-specific evidence. Worth its own re-evaluation and
+    #: benchmark on real SE hardware at some point; see ``Model8100V2`` for
+    #: the V2 override and its own caveats.
+    default_gl128_prime: bool = True
+
     x_size_mm: float = 36.0
     y_size_mm: float = 44.0
 

--- a/src/pyopticfilm/scanner.py
+++ b/src/pyopticfilm/scanner.py
@@ -46,9 +46,12 @@ logger = get_logger(__name__)
 #   <dpi>:x0,y0,x1,y1   -> custom pass, e.g. 600:0.0,0.0,1.0,0.12
 #
 # Scanner.scan(gl128_prime=False) skips the pass entirely for that call
-# (debug/testing only — expect ~30 px of first-scan position drift). It does
-# not mark the scanner as primed, so a later call without the override still
-# primes normally.
+# (expect ~30 px of first-scan position drift on models where priming is
+# actually needed). It does not mark the scanner as primed, so a later call
+# without the override still primes normally. Leave gl128_prime unset (None)
+# to use the model's own default (Model.default_gl128_prime) — True for
+# every model except the 8100 V2, which defaults to False as of 2026-08-30
+# (see model_8100_v2.py).
 _PRIME_ENV = "POF_GL128_PRIME"
 _PRIME_DEFAULT = (600, (0.0, 0.0, 1.0, 0.12))
 
@@ -302,7 +305,7 @@ class Scanner:
         single_pass_exposure: int | None = None,
         me_short_exposure: int | None = None,
         me_long_exposure: int | None = None,
-        gl128_prime: bool = True,
+        gl128_prime: bool | None = None,
     ) -> ScanImage:
         # Fail fast on bad manual-exposure input before touching the ASIC.
         validate_manual_exposure(single_pass_exposure, label="single_pass_exposure")
@@ -332,6 +335,8 @@ class Scanner:
             "me_short_exposure": me_short_exposure,
             "me_long_exposure": me_long_exposure,
         }
+        if gl128_prime is None:
+            gl128_prime = bool(getattr(self._model, "default_gl128_prime", True))
         if getattr(self._model, "asic", "") == "GL128" and not self._gl128_primed:
             if not gl128_prime:
                 # Debug/testing only: skip the discarded pass for this call.

--- a/tests/test_mock_scan.py
+++ b/tests/test_mock_scan.py
@@ -7,6 +7,7 @@ import threading
 
 import pytest
 
+from pyopticfilm.device.model_8100_v2 import MODEL_8100_V2
 from pyopticfilm.device.model_8200i import MODEL_8200I
 from pyopticfilm.device.model_8200i_se import MODEL_8200I_SE
 from pyopticfilm.device.select import create_asic, model_is_scan_ready
@@ -137,6 +138,69 @@ def test_gl128_scanner_primes_once_before_first_requested_scan(monkeypatch):
         )
         assert len(runs) == 3
         assert statuses == ["scanning"]
+    finally:
+        scanner.close()
+
+
+def test_v2_defaults_to_no_priming_when_gl128_prime_unset(monkeypatch):
+    """2026-08-30: V2 defaults gl128_prime=False (see model_8100_v2.py);
+    SE and other models are unaffected (default_gl128_prime=True)."""
+    import pyopticfilm.scan.session as session_module
+
+    scanner = Scanner.open_fake(MODEL_8100_V2)
+    sentinel = object()
+    runs: list[dict[str, object]] = []
+    statuses: list[str] = []
+
+    class FakeSession:
+        last_me_debug = None
+
+        def run(self, **kwargs):
+            runs.append(kwargs)
+            return sentinel
+
+    monkeypatch.setattr(session_module, "create_session", lambda *args: FakeSession())
+    monkeypatch.delenv("POF_GL128_PRIME", raising=False)
+    try:
+        assert (
+            scanner.scan(
+                resolution=150,
+                area=_TINY,
+                apply_calib=False,
+                on_status=statuses.append,
+            )
+            is sentinel
+        )
+        # No priming pass by default on V2 -- only the requested scan runs.
+        assert len(runs) == 1
+        assert runs[0]["resolution"] == 150
+        assert statuses == ["prime_skipped", "scanning"]
+        assert scanner._gl128_primed is False
+    finally:
+        scanner.close()
+
+
+def test_v2_gl128_prime_true_still_overrides_the_default(monkeypatch):
+    """Explicit gl128_prime=True on V2 still primes despite the new default."""
+    import pyopticfilm.scan.session as session_module
+
+    scanner = Scanner.open_fake(MODEL_8100_V2)
+    sentinel = object()
+    runs: list[dict[str, object]] = []
+
+    class FakeSession:
+        last_me_debug = None
+
+        def run(self, **kwargs):
+            runs.append(kwargs)
+            return sentinel
+
+    monkeypatch.setattr(session_module, "create_session", lambda *args: FakeSession())
+    monkeypatch.delenv("POF_GL128_PRIME", raising=False)
+    try:
+        scanner.scan(resolution=150, area=_TINY, apply_calib=False, gl128_prime=True)
+        assert len(runs) == 2  # priming pass + the requested scan
+        assert scanner._gl128_primed is True
     finally:
         scanner.close()
 


### PR DESCRIPTION
## Summary
- `Model8100V2.default_gl128_prime = False`. SE and every other model keep priming on by default (`Model8200iSE.default_gl128_prime = True`, unchanged).
- `Scanner.scan(gl128_prime=...)` now accepts `None` (new default) to mean "use the model's own default" — an explicit `True`/`False` still fully overrides it either way, so no caller-visible behavior changes unless it was relying on the old implicit `True`.

## Why
Real-hardware testing of #40's slope-table fix (a serious motor-fault regression, now root-caused and fixed) ran priming off in every single mechanically-clean trial on the 8100 V2 — 5-for-5 in an isolated build, then confirmed again on the actual working branch. Priming *on* with the slope fix in place hasn't been separately tested, so this isn't a claim that priming is harmful on V2 — just that it isn't required for the fix to work, and every hardware-proven-clean configuration so far has it off. It's still fully available via `gl128_prime=True`.

Separately, worth noting for context: GL128 priming's original rationale (~30-46px first-pass positioning drift without it) was measured and documented specifically on 8100 V2 hardware. It was extended to the SE by inheritance (shared `Gl128` ASIC code), not by independent SE measurement. This PR doesn't touch SE's default — leaving it on, since there's no SE-specific evidence either way — but flags it in a doc comment as a reasonable target for its own re-evaluation/benchmark on real SE hardware in the future.

## Test plan
- [x] `pytest` — 251 passed, 1 skipped
- [x] `ruff check` — clean
- [ ] Real V2 hardware (informally covered as part of #40's testing today — happy to add a dedicated confirmation run if useful)