### PR TITLE
fix(gl128): match 8200i SE slope tables to SilverFast and default priming off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **8200i SE positioning slope tables**: SilverFast uploads `SLOPE_TABLE_SLOW` for the first (reference) feed and `SLOPE_TABLE_FAST` for the second (final positioning) feed — 39/39 capture pairs. pyopticfilm previously used the fast ramp for both. The V2-only `use_slow_final_positioning_feed` flag is no longer on `Model8200iSE` (8100 V2 still uses fast-then-slow).
+
+### Changed
+
+- **8200i SE priming default**: `default_gl128_prime` is now `False` (same as the 8100 V2). `Scanner.scan()` with `gl128_prime` unset skips the discarded first-scan AGOHOME-park pass. Explicit `gl128_prime=True` still primes.
+
 ## [1.3.1] - 2026-08-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Other OpticFilm models **enumerate and open**: you can read status, turn the lam
 - Infrared as a dust plane on `ScanImage.ir` (`mode="infrared"`, or `infrared=True` with colour; 8200i SE only among the hardware-tested set)
 - Multi-exposure (ME) on GL128 hardware-tested models (8200i SE and 8100 V2): short + adaptive long colour passes with host SNR/IVW merge into `ScanImage.rgb` (`multi_exposure=True`); bracket planes via `Scanner.last_me_debug`
 - Manual exposure overrides on GL128 (`single_pass_exposure` / `me_short_exposure` / `me_long_exposure`) for testing/debugging: bypass the adaptive/hardware-max clamps and write an exact `REG_EXPOSURE` value (24-bit register range), never applied to the discarded priming pass
-- Priming-pass override on GL128 (`gl128_prime=False`) for testing/debugging: skip the discarded first-scan AGOHOME-park pass for one call, without disabling it for the rest of the session
+- Priming-pass override on GL128 (`gl128_prime=True` to run the discarded AGOHOME-park pass; both hardware-tested models default to skipping it)
 - Optional crop via normalized `area` (`x1, y1, x2, y2` in 0–1)
 - Dark/white shading calibration with on-disk cache (`~/.cache/pyopticfilm/calib_v2.json`)
 - GL128 ASIC shading path (AFE codes + shading blob) aligned with SilverFast capture order
@@ -163,15 +163,14 @@ image = scanner.scan(
 )
 ```
 
-Priming-pass override (GL128; debugging/testing only): GL128's first retained
-scan after open normally runs a discarded pass first (fixed 600 dpi, small
-top crop) to establish a repeatable AGOHOME park position — skipping it costs
-~30 px of first-scan position drift. `gl128_prime=False` skips that pass for
-one call without disabling it for the rest of the session: a later call
-without the override still primes normally:
+Priming-pass override (GL128; debugging/testing only): both GL128 models
+default to skipping the discarded first-scan AGOHOME-park pass. Pass
+`gl128_prime=True` to run it (fixed 600 dpi, small top crop). Skipping
+it can cost ~30 px of first-scan position drift on models where priming
+is needed:
 
 ```python
-image = scanner.scan(resolution=1800, mode="color", gl128_prime=False)
+image = scanner.scan(resolution=1800, mode="color", gl128_prime=True)
 ```
 
 Colour + IR in one call (8200i SE; IR after the colour / ME passes):

--- a/docs/scanner-validation.md
+++ b/docs/scanner-validation.md
@@ -61,11 +61,13 @@ from later passes. This is a physical positioning issue, not image alignment:
 repeated 1200 dpi full-frame scans showed a roughly 46-pixel first-to-second
 pass displacement, while later passes stayed within approximately 2 pixels.
 
-The public `Scanner.scan()` path therefore performs one discarded, single-pass
-colour scan the first time a GL128 scanner is used. That pass completes the
-normal image-session shutdown, including the capture-proven `AGOHOME` return to
-home. The requested scan then runs after this priming cycle. Priming is tracked
-per `Scanner` instance and is not repeated for later scans from that instance.
+The public `Scanner.scan()` path can perform one discarded, single-pass
+colour scan the first time a GL128 scanner is used (`gl128_prime=True`).
+That pass completes the normal image-session shutdown, including the
+capture-proven `AGOHOME` return to home. The requested scan then runs after
+this priming cycle. Priming is tracked per `Scanner` instance and is not
+repeated for later scans from that instance. Both hardware-tested GL128
+models default `gl128_prime` to off (`Model.default_gl128_prime=False`).
 
 The priming pass deliberately disables caller progress/cancel callbacks and
 multi-exposure/infrared modes. It also forces `geometry=None`,

--- a/src/pyopticfilm/asic/gl128.py
+++ b/src/pyopticfilm/asic/gl128.py
@@ -1411,17 +1411,15 @@ class Gl128:
     def _upload_fast_slopes(self, *, use_slow: bool = False) -> None:
         """Upload the motor ramp to both AHB slope windows.
 
-        2026-08-30: two independent real USB captures of the 8100 V2's
-        vendor driver show every positioning feed pair uploading
-        ``SLOPE_TABLE_FAST`` for the first (reference) feed but
-        ``SLOPE_TABLE_SLOW`` for the second (final positioning) feed —
-        exact byte match in both sources, every time. This function
-        previously always used the fast ramp regardless of caller, which
-        produced a real mechanical fault on the 8100 V2 (see the issue
-        this fix closes). Applying `use_slow` to the second feed is gated
-        per-model (``Model.use_slow_final_positioning_feed`` — see that
-        attribute's docstring) since this evidence is V2-only; SE behavior
-        is unchanged.
+        Positioning feed pairs are capture-faithful and opposite on the two
+        GL128 models. The 8100 V2 vendor driver uploads ``SLOPE_TABLE_FAST``
+        for the first (reference) feed and ``SLOPE_TABLE_SLOW`` for the
+        second (final positioning) feed; using fast for both caused a real
+        mechanical fault on V2 hardware. SilverFast on the 8200i SE is the
+        inverse: slow then fast (39/39 positioning pairs).
+        :meth:`position_for_full_frame_scan` selects the pair from
+        ``Model8100V2.use_slow_final_positioning_feed`` (V2 only; SE has no
+        such field). ``feed()`` still uploads the fast ramp.
         """
         slope = _u16_table_bytes(SLOPE_TABLE_SLOW if use_slow else SLOPE_TABLE_FAST)
         r = self.registers
@@ -1466,8 +1464,8 @@ class Gl128:
         ``FEEDFSH`` bit (confirmed on both models; the only signal used on
         the 8100 V2).
 
-        ``use_slow_slope``: pass ``True`` for the final positioning feed —
-        see ``_upload_fast_slopes``'s docstring for the capture evidence.
+        ``use_slow_slope``: pass ``True`` to upload ``SLOPE_TABLE_SLOW``
+        instead of the fast ramp — see ``_upload_fast_slopes``.
         """
         steps = max(0, int(steps))
         if steps == 0:
@@ -1629,9 +1627,15 @@ class Gl128:
             first,
             second,
         )
-        self._feed_capture(first, timeout_s=timeout_s / 2, require_motion=True)
-        use_slow_second_feed = bool(getattr(self.model, "use_slow_final_positioning_feed", False))
-        self._feed_capture(second, timeout_s=timeout_s / 2, require_motion=True, use_slow_slope=use_slow_second_feed)
+        # V2-only flag (True): fast then slow. SE has no such field → False:
+        # slow then fast, matching SilverFast (39/39 capture pairs).
+        use_slow_second = bool(getattr(self.model, "use_slow_final_positioning_feed", False))
+        self._feed_capture(
+            first, timeout_s=timeout_s / 2, require_motion=True, use_slow_slope=not use_slow_second
+        )
+        self._feed_capture(
+            second, timeout_s=timeout_s / 2, require_motion=True, use_slow_slope=use_slow_second
+        )
         end = self.read_status_reliable()
         logger.info("GL128 positioned for scan (status 0x%02x)", end.raw)
         if end.is_at_home:

--- a/src/pyopticfilm/device/model_8100_v2.py
+++ b/src/pyopticfilm/device/model_8100_v2.py
@@ -113,11 +113,11 @@ class Model8100V2(Model8200iSE):
     # not a claim that priming itself is dangerous. Still fully overridable
     # via Scanner.scan(gl128_prime=True) or a host's own UI toggle.
     default_gl128_prime: bool = False
-    # Real-hardware fault fix: two independent captures (this repo's own
-    # session, plus the recovered 04_color_7200.pcapng) show the second
-    # (final positioning) feed uses the slow motor ramp, not the fast one
-    # SE defaults to. See Model8200iSE.use_slow_final_positioning_feed's
-    # docstring — not yet independently verified on SE.
+    # V2-only: second (final positioning) feed uses SLOPE_TABLE_SLOW.
+    # Two independent V2 captures (plus recovered 04_color_7200.pcapng).
+    # 8200i SE has no such field — SilverFast there is the inverse
+    # (slow reference feed, fast final feed). See
+    # Gl128.position_for_full_frame_scan.
     use_slow_final_positioning_feed: bool = True
 
     def shading_strip_clocks(self, resolution: int, *, dvdset: bool) -> tuple[int, int, int]:

--- a/src/pyopticfilm/device/model_8200i_se.py
+++ b/src/pyopticfilm/device/model_8200i_se.py
@@ -309,14 +309,10 @@ class Model8200iSE:
 
     #: Default for ``Scanner.scan(gl128_prime=...)`` when the caller passes
     #: ``None`` (leaves the choice to the model) rather than an explicit
-    #: ``True``/``False``. SE default: unchanged, prime on. GL128 priming was
-    #: introduced (and its ~30-46px first-pass positioning benefit measured)
-    #: on the 8100 V2 specifically — it has never been independently
-    #: confirmed as needed on SE hardware, so this default is inherited
-    #: assumption, not SE-specific evidence. Worth its own re-evaluation and
-    #: benchmark on real SE hardware at some point; see ``Model8100V2`` for
-    #: the V2 override and its own caveats.
-    default_gl128_prime: bool = True
+    #: ``True``/``False``. Off: SilverFast on the SE never runs a discarded
+    #: first-scan AGOHOME-park pass, and the same default is proven safe on
+    #: the 8100 V2. Still fully overridable via ``Scanner.scan(gl128_prime=True)``.
+    default_gl128_prime: bool = False
 
     x_size_mm: float = 36.0
     y_size_mm: float = 44.0
@@ -445,17 +441,6 @@ class Model8200iSE:
     #: 13.06 mm height of the 09a crop above it, so the two halves overlap by
     #: half a millimetre and together cover the 25.59 mm window.
     feed_to_scan_bottom_steps: int = 20232
-
-    #: Whether the second (final positioning) feed in
-    #: ``position_for_full_frame_scan()`` uploads the slow motor ramp
-    #: instead of the fast one. Verified on the 8100 V2 from two independent
-    #: real captures (see ``Model8100V2``'s override and the linked issue);
-    #: **not independently verified on the SE** — SE hardware has not been
-    #: captured for this specific behavior, even though the raw
-    #: ``SLOPE_TABLE_FAST``/``SLOPE_TABLE_SLOW`` values themselves are
-    #: SE-session-derived. Defaults to the SE's original (unchanged)
-    #: behavior — fast for both feeds — until SE-specific evidence exists.
-    use_slow_final_positioning_feed: bool = False
 
     #: Largest single FEEDL observed in captures; refuse anything larger.
     max_feed_steps: int = 28292

--- a/src/pyopticfilm/scanner.py
+++ b/src/pyopticfilm/scanner.py
@@ -48,10 +48,10 @@ logger = get_logger(__name__)
 # Scanner.scan(gl128_prime=False) skips the pass entirely for that call
 # (expect ~30 px of first-scan position drift on models where priming is
 # actually needed). It does not mark the scanner as primed, so a later call
-# without the override still primes normally. Leave gl128_prime unset (None)
-# to use the model's own default (Model.default_gl128_prime) — True for
-# every model except the 8100 V2, which defaults to False as of 2026-08-30
-# (see model_8100_v2.py).
+# without the override still primes if the model's default is on. Leave
+# gl128_prime unset (None) to use the model's own default
+# (Model.default_gl128_prime) — False for both GL128 models (8200i SE and
+# 8100 V2). Explicit gl128_prime=True still primes.
 _PRIME_ENV = "POF_GL128_PRIME"
 _PRIME_DEFAULT = (600, (0.0, 0.0, 1.0, 0.12))
 
@@ -336,7 +336,7 @@ class Scanner:
             "me_long_exposure": me_long_exposure,
         }
         if gl128_prime is None:
-            gl128_prime = bool(getattr(self._model, "default_gl128_prime", True))
+            gl128_prime = bool(getattr(self._model, "default_gl128_prime", False))
         if getattr(self._model, "asic", "") == "GL128" and not self._gl128_primed:
             if not gl128_prime:
                 # Debug/testing only: skip the discarded pass for this call.

--- a/tests/test_gl128_slope_table.py
+++ b/tests/test_gl128_slope_table.py
@@ -1,12 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""GL128 motor slope-table selection per feed (2026-08-30 real-hardware fault).
+"""GL128 motor slope-table selection per feed.
 
-Two independent real captures (a second capture session's files, and the
-original vendor capture ``04_color_7200.pcapng``) show every positioning
-feed pair uploading ``SLOPE_TABLE_FAST`` for the first (reference) feed but
-``SLOPE_TABLE_SLOW`` for the second (final positioning) feed — exact byte
-match in both sources, every time. pyopticfilm previously always used the
-fast ramp for both feeds. See docs/hw-ref/8100v2/PROGRESS.md.
+8100 V2 vendor captures: first (reference) feed ``SLOPE_TABLE_FAST``, second
+(final positioning) feed ``SLOPE_TABLE_SLOW``. 8200i SE SilverFast captures
+are the inverse (slow then fast; 39/39 positioning pairs). ``feed()`` still
+uploads the fast ramp on both models.
 """
 
 from __future__ import annotations
@@ -103,13 +101,14 @@ def test_position_for_full_frame_scan_uses_fast_then_slow_on_v2(monkeypatch):
     assert ahb_writes[3] == slow
 
 
-def test_position_for_full_frame_scan_stays_fast_on_se(monkeypatch):
-    """Regression guard: SE is unaffected by the V2-only slope fix.
+def test_v2_only_flag_is_absent_on_se():
+    """SE must not expose the V2 slow-final-feed flag (hosts cannot select it)."""
+    assert not hasattr(MODEL_8200I_SE, "use_slow_final_positioning_feed")
+    assert MODEL_8100_V2.use_slow_final_positioning_feed is True
 
-    This evidence is V2-only (see Model8200iSE.use_slow_final_positioning_
-    feed's docstring) -- SE must keep using the fast ramp for both feeds,
-    exactly as before this fix, until SE-specific evidence exists.
-    """
+
+def test_position_for_full_frame_scan_uses_slow_then_fast_on_se(monkeypatch):
+    """SE SilverFast: first feed SLOW, second FAST (inverse of V2)."""
     usb = MockScannerTransport()
     protocol = GenesysUsbProtocol(usb)
     asic = create_asic(protocol, MODEL_8200I_SE)
@@ -119,5 +118,9 @@ def test_position_for_full_frame_scan_stays_fast_on_se(monkeypatch):
     asic.position_for_full_frame_scan(scan_steps=13704)
 
     fast = _pack(SLOPE_TABLE_FAST)
-    assert len(ahb_writes) == 4
-    assert all(w == fast for w in ahb_writes), "SE must stay fast-fast, not fast-slow"
+    slow = _pack(SLOPE_TABLE_SLOW)
+    assert len(ahb_writes) == 4  # 2 windows x 2 feeds
+    assert ahb_writes[0] == slow
+    assert ahb_writes[1] == slow
+    assert ahb_writes[2] == fast
+    assert ahb_writes[3] == fast

--- a/tests/test_manual_exposure.py
+++ b/tests/test_manual_exposure.py
@@ -264,6 +264,7 @@ def test_scanner_scan_threads_manual_exposure_to_session_not_prime(monkeypatch):
             single_pass_exposure=12345,
             me_short_exposure=6789,
             me_long_exposure=99999,
+            gl128_prime=True,
         )
     finally:
         scanner.close()

--- a/tests/test_mock_scan.py
+++ b/tests/test_mock_scan.py
@@ -108,10 +108,10 @@ def test_gl128_scanner_primes_once_before_first_requested_scan(monkeypatch):
                 area=_TINY,
                 apply_calib=False,
                 on_status=statuses.append,
+                gl128_prime=True,
             )
             is sentinel
         )
-        assert len(runs) == 2
         # Default prime: fixed small pass, independent of requested PPI/area.
         assert runs[0]["resolution"] == 600
         assert runs[0]["area"] == (0.0, 0.0, 1.0, 0.12)
@@ -125,6 +125,7 @@ def test_gl128_scanner_primes_once_before_first_requested_scan(monkeypatch):
         assert runs[1]["resolution"] == 150
         assert runs[1]["area"] == _TINY
         assert statuses == ["priming", "scanning"]
+        assert len(runs) == 2
 
         statuses.clear()
         assert (
@@ -142,12 +143,12 @@ def test_gl128_scanner_primes_once_before_first_requested_scan(monkeypatch):
         scanner.close()
 
 
-def test_v2_defaults_to_no_priming_when_gl128_prime_unset(monkeypatch):
-    """2026-08-30: V2 defaults gl128_prime=False (see model_8100_v2.py);
-    SE and other models are unaffected (default_gl128_prime=True)."""
+@pytest.mark.parametrize("model", [MODEL_8200I_SE, MODEL_8100_V2])
+def test_gl128_defaults_to_no_priming_when_gl128_prime_unset(monkeypatch, model):
+    """Both GL128 models default gl128_prime=False when the caller passes None."""
     import pyopticfilm.scan.session as session_module
 
-    scanner = Scanner.open_fake(MODEL_8100_V2)
+    scanner = Scanner.open_fake(model)
     sentinel = object()
     runs: list[dict[str, object]] = []
     statuses: list[str] = []
@@ -171,7 +172,6 @@ def test_v2_defaults_to_no_priming_when_gl128_prime_unset(monkeypatch):
             )
             is sentinel
         )
-        # No priming pass by default on V2 -- only the requested scan runs.
         assert len(runs) == 1
         assert runs[0]["resolution"] == 150
         assert statuses == ["prime_skipped", "scanning"]
@@ -236,14 +236,14 @@ def test_gl128_prime_skipped_when_gl128_prime_false(monkeypatch):
         assert statuses == ["prime_skipped", "scanning"]
         assert scanner._gl128_primed is False
 
-        # A later call without the override still primes normally, since
-        # skipping never marked the scanner as primed.
+        # Skipping never marked the scanner as primed; an explicit True still primes.
         statuses.clear()
         scanner.scan(
             resolution=150,
             area=_TINY,
             apply_calib=False,
             on_status=statuses.append,
+            gl128_prime=True,
         )
         assert len(runs) == 3
         assert runs[1]["resolution"] == 600  # the (now-run) discarded prime
@@ -279,6 +279,7 @@ def test_gl128_prime_ignores_caller_geometry_and_calib(monkeypatch):
             apply_calib=True,
             mode="infrared",
             infrared=True,
+            gl128_prime=True,
         )
         assert len(runs) == 2
         assert runs[0]["resolution"] == 600
@@ -310,7 +311,7 @@ def test_gl128_prime_env_override_full_and_custom(monkeypatch):
 
         monkeypatch.setattr(session_module, "create_session", lambda *args: FakeSession())
         try:
-            scanner.scan(resolution=3600, area=None, apply_calib=False)
+            scanner.scan(resolution=3600, area=None, apply_calib=False, gl128_prime=True)
         finally:
             scanner.close()
         return runs[0]

--- a/tests/test_scanlab_worker.py
+++ b/tests/test_scanlab_worker.py
@@ -41,7 +41,7 @@ def test_run_scan_accepts_positional_signal_args():
 
 
 def test_run_prescan_accepts_positional_signal_args():
-    # request_prescan = pyqtSignal(object, bool, bool)
+    # request_prescan = pyqtSignal(object, bool, object)
     positional, keyword_only = _method_args("run_prescan")
     assert positional == ["target", "apply_calib", "gl128_prime"]
     assert keyword_only == []

--- a/tools/scanlab/README.md
+++ b/tools/scanlab/README.md
@@ -91,7 +91,7 @@ scan-ready GL128 **8100 (V2)** (`07b3:1824`).
 | **USB planar RGB** | Off = chunky `RGBRGB…` (default). On = planar planes — try this if Prescan is rainbow-striped. |
 | **Adaptive quiet drain** | On (default). Rate-limits host bulk reads to the ASIC `LPERIOD` line rate (including 7200 dpi, ~3.55 ms/line) so motor creep stays continuous. Uncheck for fastest drain (louder). |
 | **Slow image slope** | Off (default). On: shading/slow motor ramp on the image pass (feeds stay fast). |
-| **Disable priming pass (debug)** | GL128 only. Off (default). On: skip the discarded first-scan AGOHOME-park pass on both Prescan and Scan — debug/testing only, expect ~30 px of first-scan position drift. Unchecking it lets the scanner prime normally on the next Prescan/Scan. |
+| **Disable priming pass (debug)** | GL128 only. Off (default): use the model's priming default (off for 8200i SE and 8100 V2). On: skip the discarded first-scan AGOHOME-park pass on both Prescan and Scan. |
 | **Refresh devices** | Re-enumerate USB and rebuild the device list. |
 | **PPI** | Resolutions from the selected model’s `resolutions_dpi` (Scan only; Prescan uses a fixed low dpi). |
 | **IR pass** | After colour Scan, run a second infrared pass (disabled if the model has no IR). |
@@ -192,14 +192,15 @@ Live truncated log of every control and bulk transfer through the recording
 USB wrapper. **Open capture…** also fills this tab from the pcap (identical
 line format; repeated bulk-IN lengths are collapsed as ``×N``).
 
-- Dividers mark `PRIMING` (or `PRIMING SKIPPED (debug)` when **Disable priming pass** is on), `PRESCAN`, `SCAN`, `IR`, and `CAPTURE` sections.
+- Dividers mark `PRIMING` (or `PRIMING SKIPPED (debug)` when priming is skipped), `PRESCAN`, `SCAN`, `IR`, and `CAPTURE` sections.
 - **Jump** buttons scroll to those dividers when present.
 - **Clear USB log** empties the buffer (Prescan also clears the log).
 
 Progress for the active pass is shown in the status bar. On the first scan
-after open (GL128), the status bar shows **Priming scanner…** while the
-discarded AGOHOME park pass runs, then **Scanning…** — or **Priming skipped
-(debug)…** when **Disable priming pass (debug)** is checked.
+after open (GL128), the status bar shows **Priming scanner…** if an explicit
+prime was requested, then **Scanning…** — or **Priming skipped (debug)…**
+when the model default skips priming or **Disable priming pass (debug)** is
+checked.
 
 ## Geometry notes
 

--- a/tools/scanlab/app.py
+++ b/tools/scanlab/app.py
@@ -132,12 +132,10 @@ class ScanLabWindow(QMainWindow):
         self.disable_gl128_prime = QCheckBox("Disable priming pass (debug)")
         self.disable_gl128_prime.setChecked(False)
         self.disable_gl128_prime.setToolTip(
-            "GL128 only. Off (default): the first Prescan/Scan after open runs "
-            "a discarded small pass that establishes the repeatable AGOHOME "
-            "park position. On: skip that pass — for debugging/testing only; "
-            "expect ~30 px of first-scan position drift versus the primed "
-            "baseline. The scanner still primes normally on a later "
-            "Prescan/Scan once this is unchecked again."
+            "GL128 only. Off (default): use the model's priming default "
+            "(currently off for 8200i SE and 8100 V2). On: skip the discarded "
+            "first-scan AGOHOME-park pass — for debugging/testing only. "
+            "Explicit priming is still available via Scanner.scan(gl128_prime=True)."
         )
         form.addWidget(self.disable_gl128_prime)
 
@@ -834,6 +832,12 @@ class ScanLabWindow(QMainWindow):
             slow_image_slope=self.slow_image_slope.isChecked(),
         )
 
+    def _gl128_prime_arg(self) -> bool | None:
+        """False when the debug box is on; otherwise leave the model default."""
+        if self.disable_gl128_prime.isChecked():
+            return False
+        return None
+
     def _clear_scan_tabs(self) -> None:
         """Drop prior prescan/scan results so a new Prescan starts a fresh session."""
         self._last_scan = None
@@ -865,7 +869,7 @@ class ScanLabWindow(QMainWindow):
         self._worker.request_prescan.emit(
             target,
             self.apply_calib.isChecked(),
-            not self.disable_gl128_prime.isChecked(),
+            self._gl128_prime_arg(),
         )
 
     def _on_scan(self) -> None:
@@ -922,7 +926,7 @@ class ScanLabWindow(QMainWindow):
             single_pass_exposure,
             me_short_exposure,
             me_long_exposure,
-            not self.disable_gl128_prime.isChecked(),
+            self._gl128_prime_arg(),
         )
 
     def _on_progress(self, value: float) -> None:

--- a/tools/scanlab/worker.py
+++ b/tools/scanlab/worker.py
@@ -34,11 +34,11 @@ class ScanWorker(QObject):
     failed = pyqtSignal(str)
     busy_changed = pyqtSignal(bool)
     calib_cleared = pyqtSignal(str)
-    #: target, apply_calib, gl128_prime
-    request_prescan = pyqtSignal(object, bool, bool)
+    #: target, apply_calib, gl128_prime (bool or None for model default)
+    request_prescan = pyqtSignal(object, bool, object)
     #: target, dpi, ir_pass, me_pass, crop_norm, apply_calib, me_exposure_mode,
     #: single_pass_exposure, me_short_exposure, me_long_exposure, gl128_prime
-    request_scan = pyqtSignal(object, int, bool, bool, object, bool, str, object, object, object, bool)
+    request_scan = pyqtSignal(object, int, bool, bool, object, bool, str, object, object, object, object)
 
     def __init__(self) -> None:
         super().__init__()
@@ -119,7 +119,7 @@ class ScanWorker(QObject):
         self,
         target: LabTarget,
         apply_calib: bool = False,
-        gl128_prime: bool = True,
+        gl128_prime: bool | None = None,
     ) -> None:
         self._run(
             target,
@@ -129,7 +129,7 @@ class ScanWorker(QObject):
             me=False,
             crop=None,
             apply_calib=bool(apply_calib),
-            gl128_prime=bool(gl128_prime),
+            gl128_prime=gl128_prime,
         )
 
     def run_scan(
@@ -144,7 +144,7 @@ class ScanWorker(QObject):
         single_pass_exposure: int | None = None,
         me_short_exposure: int | None = None,
         me_long_exposure: int | None = None,
-        gl128_prime: bool = True,
+        gl128_prime: bool | None = None,
     ) -> None:
         self._run(
             target,
@@ -158,7 +158,7 @@ class ScanWorker(QObject):
             single_pass_exposure=single_pass_exposure,
             me_short_exposure=me_short_exposure,
             me_long_exposure=me_long_exposure,
-            gl128_prime=bool(gl128_prime),
+            gl128_prime=gl128_prime,
         )
 
     def _run(
@@ -175,7 +175,7 @@ class ScanWorker(QObject):
         single_pass_exposure: int | None = None,
         me_short_exposure: int | None = None,
         me_long_exposure: int | None = None,
-        gl128_prime: bool = True,
+        gl128_prime: bool | None = None,
     ) -> None:
         self.busy_changed.emit(True)
         self._cancel.clear()


### PR DESCRIPTION
## Summary

- 8200i SE positioning now matches SilverFast: `SLOPE_TABLE_SLOW` on the 28292 reference feed, `SLOPE_TABLE_FAST` on the final feed (39/39 USBPcap pairs; inverse of the 8100 V2).
- Removed `use_slow_final_positioning_feed` from `Model8200iSE` so hosts cannot select the V2 pair on SE. The flag stays `True` only on `Model8100V2` (fast then slow, unchanged).
- SE `default_gl128_prime` is now `False` (same as V2). Scan Lab uses the model default unless **Disable priming pass** is checked. `gl128_prime=True` still primes.

Follow-up to #40 / #41: those PRs correctly left SE alone until we had SE captures. Flipping V2’s `use_slow_final_positioning_feed` on SE would have been the wrong feed.

## Test plan

- [x] Slope tests: SE slow-then-fast, V2 fast-then-slow, SE has no `use_slow_final_positioning_feed`
- [x] Priming tests: both GL128 models skip by default; `gl128_prime=True` still primes
- [x] Full suite (257 passed, 2 skipped)
- [x] Real 8200i SE: consecutive full scans at a few DPIs; first (long) feed should sound gentler than before, final approach still the fast ramp