### PR TITLE
fix(gl128): lock short-plane ENDPIXEL dummy drop across ME/IR passes …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.3.3] - 2026-08-30
+
 ### Added
 
 - **Model-lock tests** (`tests/model_lock/`): frozen 8200i SE driver-path oracles (geometry, crop mapping, dummy trim, slope-table feed order, ME configure, Scan Lab window kwargs). Other-model fixes must specialize that model rather than retarget these asserts. Run with `uv run pytest -m model_lock`.
+
+### Fixed
+
+- **ME short/long width mismatch**: content-aware ENDPIXEL dummy trim could drop a different column count on short vs long (and IR) because edge DN differs — especially at 3600 dpi where the cap is larger. Multi-pass now discovers the drop on the short/first colour plane and reuses it for long and IR assemble so merge/align see matching widths. Single-pass stays content-aware.
 
 ## [1.3.2] - 2026-08-30
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Not implemented or out of scope here: iSRD infrared dust removal, SilverFast-sty
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for release notes. Latest release: [v1.3.2 on GitHub](https://github.com/jboneng/pyopticfilm/releases/tag/v1.3.2).
+See [CHANGELOG.md](CHANGELOG.md) for release notes. Latest release: [v1.3.3 on GitHub](https://github.com/jboneng/pyopticfilm/releases/tag/v1.3.3).
 
 ## Requirements
 

--- a/src/pyopticfilm/_version.py
+++ b/src/pyopticfilm/_version.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Package version (kept in sync with pyproject.toml)."""
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"

--- a/src/pyopticfilm/scan/pipeline.py
+++ b/src/pyopticfilm/scan/pipeline.py
@@ -103,6 +103,9 @@ class ImagePipeline:
 
     def __init__(self, model: FilmModel = MODEL_8200I) -> None:
         self.model = model
+        #: Columns dropped from the USB ENDPIXEL side on the last :meth:`assemble`.
+        #: Multi-pass callers lock the short-plane value for long/IR assemble.
+        self.last_usb_end_drop: int = 0
 
     @staticmethod
     def _inset_slice(h: int, w: int, inset: float) -> tuple[slice, slice] | None:
@@ -444,15 +447,18 @@ class ImagePipeline:
         white: np.ndarray | None = None,
         planar: bool | None = None,
         expose_base: bool = True,
+        usb_end_drop: int | None = None,
     ) -> np.ndarray:
         """Decode USB RGB and apply calib / optional film-base makeup.
 
         ``expose_base=False`` skips scalar peak stretch and border clamp so ME
         short/long planes stay linear (SilverFast-wire scale) for host merge.
 
-        Image width equals the programmed STR/END span minus a content-aware
-        ENDPIXEL dummy trim (capped at ``geometry.usb_end_drop``). Pcap 7200
-        may still drop dummy URB columns via :func:`trim_to_optical_span`.
+        Image width equals the programmed STR/END span minus an ENDPIXEL dummy
+        trim (capped at ``geometry.usb_end_drop``). With ``usb_end_drop=None``
+        the trim is content-aware; pass an ``int`` to reuse a locked drop from
+        an earlier plane (ME short → long/IR) so widths match. Pcap 7200 may
+        still drop dummy URB columns via :func:`trim_to_optical_span`.
         """
         rgb = self.decode_rgb(raw, geometry=geometry, planar=planar)
         rgb = self.reduce_y_oversample(rgb, geometry)
@@ -461,7 +467,11 @@ class ImagePipeline:
         rgb = self.apply_host_downsample(rgb, geometry)
         rgb = trim_to_optical_span(rgb, geometry)
         cap = 0 if geometry.disable_buffer_full_move else int(getattr(geometry, "usb_end_drop", 0) or 0)
-        drop = count_usb_end_dummy_columns(rgb, max_drop=cap)
+        if usb_end_drop is None:
+            drop = count_usb_end_dummy_columns(rgb, max_drop=cap)
+        else:
+            drop = max(0, min(int(usb_end_drop), cap, max(0, rgb.shape[1] - 8)))
+        self.last_usb_end_drop = drop
         if drop > 0:
             rgb = np.ascontiguousarray(rgb[:, : rgb.shape[1] - drop, :])
             logger.info(

--- a/src/pyopticfilm/scan/session_gl128.py
+++ b/src/pyopticfilm/scan/session_gl128.py
@@ -411,6 +411,9 @@ class Gl128ScanSession(ScanSession):
         rgb_long = None
         ir_plane = None
         exposure_decision = None
+        # Content-aware ENDPIXEL drop from the short plane; reuse for long/IR
+        # so merge/align see matching widths (edge DN differs across exposures).
+        locked_usb_end_drop: int | None = None
 
         def _acquire_pass(
             *,
@@ -422,7 +425,7 @@ class Gl128ScanSession(ScanSession):
             long_pass: bool,
             manual: bool = False,
         ):
-            nonlocal rgb_short, rgb_long, ir_plane
+            nonlocal rgb_short, rgb_long, ir_plane, locked_usb_end_drop
 
             def _prog(p: float, _i: int = idx) -> None:
                 if progress is not None:
@@ -487,6 +490,8 @@ class Gl128ScanSession(ScanSession):
             planar = getattr(self.asic, "usb_planar_rgb", None)
             if planar is None:
                 planar = bool(getattr(self.model, "usb_planar_rgb", False))
+            # Short discovers the dummy trim; later planes reuse that drop.
+            drop_override = None if key == "color_short" else locked_usb_end_drop
             rgb = self.pipeline.assemble(
                 raw,
                 geometry,
@@ -496,9 +501,10 @@ class Gl128ScanSession(ScanSession):
                 # Keep ME colour (and IR) planes linear — per-plane expose_film_base
                 # collapses the short/long ratio. Makeup runs once on the deliverable.
                 expose_base=False,
+                usb_end_drop=drop_override,
             )
-
             if key == "color_short":
+                locked_usb_end_drop = int(self.pipeline.last_usb_end_drop)
                 rgb_short = rgb
             elif key == "color_long":
                 rgb_long = rgb

--- a/tests/model_lock/opticfilm_8200i_se/test_usb_end_dummy.py
+++ b/tests/model_lock/opticfilm_8200i_se/test_usb_end_dummy.py
@@ -75,3 +75,47 @@ def test_assemble_keeps_left_frame_when_no_dummy(monkeypatch):
     out = _assemble_passthrough(monkeypatch, geo, rgb)
     assert out.shape[1] == geo.pixels
     assert int(out[:, 0, 0].mean()) > 10_000
+
+
+def test_locked_usb_end_drop_equalizes_me_short_long_widths(monkeypatch):
+    """Short discovers dark END columns; long without them must reuse that drop."""
+    from pyopticfilm.scan.exposure_merge import merge_exposures_result
+
+    geo = compute_geometry(1800, model=MODEL_8200I_SE, area=(0.15, 0.2, 0.7, 0.6))
+    assert geo.usb_end_drop == 24
+    h = max(4, geo.lines)
+    w = geo.pixels
+
+    short_raw = np.full((h, w, 3), 18_000, dtype=np.uint16)
+    short_raw[:, -16:, :] = 200  # 16 true dummy columns
+    long_raw = np.full((h, w, 3), 40_000, dtype=np.uint16)
+    # Long edge is bright — heuristic alone would drop 0.
+
+    pipe = ImagePipeline(MODEL_8200I_SE)
+    monkeypatch.setattr(pipe, "reduce_y_oversample", lambda arr, _g: arr)
+    monkeypatch.setattr(pipe, "apply_line_shifts", lambda arr, _g: arr)
+    monkeypatch.setattr(pipe, "apply_y_stagger", lambda arr, _g: arr)
+    monkeypatch.setattr(pipe, "apply_host_downsample", lambda arr, _g: arr)
+
+    monkeypatch.setattr(pipe, "decode_rgb", lambda *_a, **_k: short_raw.copy())
+    out_short_heuristic = pipe.assemble(b"", geo, dark=None, white=None, expose_base=False)
+    monkeypatch.setattr(pipe, "decode_rgb", lambda *_a, **_k: long_raw.copy())
+    out_long_heuristic = pipe.assemble(b"", geo, dark=None, white=None, expose_base=False)
+    assert out_short_heuristic.shape[1] != out_long_heuristic.shape[1]
+
+    monkeypatch.setattr(pipe, "decode_rgb", lambda *_a, **_k: short_raw.copy())
+    out_short = pipe.assemble(b"", geo, dark=None, white=None, expose_base=False)
+    locked = int(pipe.last_usb_end_drop)
+    assert locked == 16
+
+    monkeypatch.setattr(pipe, "decode_rgb", lambda *_a, **_k: long_raw.copy())
+    out_long = pipe.assemble(
+        b"", geo, dark=None, white=None, expose_base=False, usb_end_drop=locked
+    )
+    assert out_short.shape == out_long.shape
+    assert pipe.last_usb_end_drop == locked
+
+    merged = merge_exposures_result(
+        out_short, out_long, exposure_short=14000, exposure_long=42000
+    )
+    assert merged.rgb.shape == out_short.shape

--- a/tests/test_me.py
+++ b/tests/test_me.py
@@ -67,6 +67,44 @@ def test_assemble_expose_base_false_preserves_me_ratio():
     assert ratio_exposed < 1.5
 
 
+def test_locked_usb_end_drop_allows_me_merge_when_edges_differ():
+    """ME short/long with unequal dark END columns merge when drop is locked."""
+    from pyopticfilm.scan.geometry import compute_geometry
+    from pyopticfilm.scan.pipeline import ImagePipeline
+
+    pipe = ImagePipeline(MODEL_8200I_SE)
+    geometry = compute_geometry(3600, model=MODEL_8200I_SE, area=(0.15, 0.2, 0.7, 0.6))
+    assert geometry.usb_end_drop == 48
+    h = max(4, geometry.lines)
+    w = geometry.pixels
+    short = np.full((h, w, 3), 12_000, dtype=np.uint16)
+    short[:, -24:, :] = 100
+    long = np.full((h, w, 3), 36_000, dtype=np.uint16)
+
+    pipe.reduce_y_oversample = lambda rgb, _g: rgb  # type: ignore[method-assign]
+    pipe.apply_line_shifts = lambda rgb, _g: rgb  # type: ignore[method-assign]
+    pipe.apply_y_stagger = lambda rgb, _g: rgb  # type: ignore[method-assign]
+    pipe.apply_host_downsample = lambda rgb, _g: rgb  # type: ignore[method-assign]
+
+    pipe.decode_rgb = lambda *_a, **_k: short.copy()  # type: ignore[method-assign]
+    out_s = pipe.assemble(b"S", geometry, dark=None, white=None, expose_base=False)
+    locked = pipe.last_usb_end_drop
+    assert locked == 24
+
+    pipe.decode_rgb = lambda *_a, **_k: long.copy()  # type: ignore[method-assign]
+    out_l_unlocked = pipe.assemble(b"L", geometry, dark=None, white=None, expose_base=False)
+    assert out_l_unlocked.shape[1] != out_s.shape[1]
+
+    out_l = pipe.assemble(
+        b"L", geometry, dark=None, white=None, expose_base=False, usb_end_drop=locked
+    )
+    assert out_s.shape == out_l.shape
+    result = merge_exposures_result(
+        out_s, out_l, exposure_short=14000, exposure_long=42000
+    )
+    assert result.rgb.shape == out_s.shape
+
+
 def test_assemble_expose_base_false_skips_makeup_hooks():
     from pyopticfilm.scan.geometry import compute_geometry
     from pyopticfilm.scan.pipeline import ImagePipeline


### PR DESCRIPTION
…so merge sees equal widths