### PR TITLE
fix(gl128): resolve N-bracket + 2x ME ghosting on 8100 V2 (alignment guard, row-banded shift, luma-only fallback)

### DIFF
--- a/src/pyopticfilm/device/gl128_common.py
+++ b/src/pyopticfilm/device/gl128_common.py
@@ -262,6 +262,7 @@ GL128_DIVERGENT_FIELDS: frozenset[str] = frozenset(
         "ladder_feed2_steps",
         "use_slow_final_positioning_feed",
         "me_default_exposure_mode",
+        "me_use_banded_alignment",
     }
 )
 

--- a/src/pyopticfilm/device/model_8100_v2.py
+++ b/src/pyopticfilm/device/model_8100_v2.py
@@ -112,6 +112,15 @@ class Model8100V2(Gl128Common):
     #: defaults to ``"adaptive"``.
     me_default_exposure_mode: str = "fixed"
 
+    #: Use row-banded pass alignment (pyopticfilm.pass_align.
+    #: align_pass_to_reference_banded) and the N-bracket merge's luma-only
+    #: misalignment gate for the 2-bracket ME path too, not just
+    #: n_brackets > 2. V2-only: independently measured near-pure Y-axis
+    #: drift that grows along a tall pass (see jboneng/pyopticfilm#33) and
+    #: real-hardware ghosting on flat/neutral content this addresses are
+    #: both V2-specific so far; SE keeps the original byte-identical path.
+    me_use_banded_alignment: bool = True
+
     def me_n_bracket_long_exposure_ceiling(self, resolution: int) -> int:
         """Pin N-bracket (``n_brackets > 2``) longs at 42000 for every DPI.
 

--- a/src/pyopticfilm/device/model_8200i_se.py
+++ b/src/pyopticfilm/device/model_8200i_se.py
@@ -86,5 +86,10 @@ class Model8200iSE(Gl128Common):
     #: ``"adaptive"`` regardless of this field.
     me_default_exposure_mode: str = "adaptive"
 
+    #: Row-banded alignment / luma-only misalignment gate for the 2-bracket
+    #: ME path — see Model8100V2 for why. Not validated on SE hardware;
+    #: keep the original byte-identical 2-bracket path here.
+    me_use_banded_alignment: bool = False
+
 
 MODEL_8200I_SE = Model8200iSE()

--- a/src/pyopticfilm/device/protocol.py
+++ b/src/pyopticfilm/device/protocol.py
@@ -136,6 +136,7 @@ class Gl128Model(FilmModel, Protocol):
     me_noise_alpha: float
     me_noise_beta: float
     me_default_exposure_mode: str
+    me_use_banded_alignment: bool
     feed_steps_per_inch: int
     feed_to_reference_steps: int
     feed_to_scan_steps: int

--- a/src/pyopticfilm/pass_align.py
+++ b/src/pyopticfilm/pass_align.py
@@ -15,19 +15,30 @@ from pyopticfilm.logging import get_logger
 logger = get_logger(__name__)
 
 _ALIGN_PROBE_WIDTH = 1024
-_ALIGN_MAX_SHIFT_FRAC = 0.02
 _REFINE_ROI_SIDE = 2048
 _REFINE_MAX_RESIDUAL = 2.0
 
+# Trust gate for a phase-correlation result: cv2.phaseCorrelate's own
+# peak-sharpness score, not shift magnitude. Real hardware drift on this
+# GL128 platform is routinely 20-40px+ (jboneng/pyopticfilm#33's own
+# benchmark measured up to ~42px) — a magnitude-based cutoff rejects real,
+# correctable shifts no matter how it's scaled to the frame. A weak/
+# ambiguous correlation peak (low response) is what actually indicates an
+# untrustworthy result — e.g. the bogus ~46px lock onto low-texture content
+# noted in jboneng/pyopticfilm#14 — regardless of the shift's size.
+_ALIGN_MIN_RESPONSE = 0.05
+# Generous absolute sanity ceiling on top of the response gate — catches
+# only a truly pathological result (e.g. a shift larger than the frame
+# itself), not a plausible-but-large real one.
+_ALIGN_SANITY_MAX_FRAC = 0.5
+
 # Row-banded alignment (see align_pass_to_reference_banded): a tall pass can
 # drift progressively along the feed axis rather than by one constant
-# offset (near-pure Y-axis drift, worse at high DPI/long feeds — see
-# jboneng/pyopticfilm#33), so a single whole-frame shift under- or
-# over-corrects depending on how far a region sits from wherever the
-# dominant texture anchored the estimate.
+# offset, so a single whole-frame shift under- or over-corrects depending
+# on how far a region sits from wherever the dominant texture anchored the
+# estimate.
 _ALIGN_BAND_COUNT = 8
 _ALIGN_BAND_MIN_HEIGHT = 256  # below this, banding has too little signal per band
-_ALIGN_BAND_MIN_RESPONSE = 0.05  # cv2.phaseCorrelate's own peak-sharpness score
 _ALIGN_BAND_OUTLIER_PX = 8.0
 
 Shift2D = tuple[float, float]
@@ -91,19 +102,24 @@ def _roi_luminance(image: np.ndarray, y0: int, x0: int, rh: int, rw: int) -> np.
     return roi.astype(np.float32)
 
 
-def _phase_correlate_shift(ref: np.ndarray, mov: np.ndarray, *, scale: float) -> Shift2D:
+def _phase_correlate_shift(
+    ref: np.ndarray, mov: np.ndarray, *, scale: float
+) -> tuple[float, float, float]:
+    """Returns ``(dx, dy, response)`` — response is cv2.phaseCorrelate's own
+    peak-sharpness score (0..1ish), the trust signal used by both the
+    whole-frame guard and the row-banded per-band filter."""
     try:
         import cv2
     except ImportError:
-        return (0.0, 0.0)
+        return (0.0, 0.0, 0.0)
     if ref.size == 0 or mov.size == 0 or ref.shape != mov.shape:
-        return (0.0, 0.0)
+        return (0.0, 0.0, 0.0)
     h, w = ref.shape[:2]
     win = cv2.createHanningWindow((w, h), cv2.CV_32F)
-    (dx, dy), _resp = cv2.phaseCorrelate(
+    (dx, dy), resp = cv2.phaseCorrelate(
         np.ascontiguousarray(mov), np.ascontiguousarray(ref), win
     )
-    return float(dx * scale), float(dy * scale)
+    return float(dx * scale), float(dy * scale), float(resp)
 
 
 def _refine_pass_shift(
@@ -128,30 +144,32 @@ def _refine_pass_shift(
     x0 = max(0, (w - rw) // 2)
     ref_lum = _roi_luminance(reference, y0, x0, rh, rw)
     mov_lum = _roi_luminance(warped, y0, x0, rh, rw)
-    ddx, ddy = _phase_correlate_shift(ref_lum, mov_lum, scale=1.0)
-    if max(abs(ddx), abs(ddy)) > _REFINE_MAX_RESIDUAL:
+    ddx, ddy, resp = _phase_correlate_shift(ref_lum, mov_lum, scale=1.0)
+    if resp < _ALIGN_MIN_RESPONSE or max(abs(ddx), abs(ddy)) > _REFINE_MAX_RESIDUAL:
         return coarse
     return dx0 + ddx, dy0 + ddy
 
 
-def _shift_exceeds_guard(dx: float, dy: float, full_w: int, full_h: int) -> bool:
-    """True when ``dx``/``dy`` looks like a bogus phase-correlation result.
-
-    Each axis is checked against its own dimension — a tall crop/strip window
-    can have a legitimately large vertical drift relative to its (narrow)
-    width, and a wide window can have a legitimately large horizontal drift
-    relative to its (short) height. Judging both axes off a single
-    width-derived guard rejects real, correctable shifts on non-square
-    windows (e.g. a 1096x6700 strip crop, where a ~200px real dy is only
-    ~3% of height but ~9x a width-derived guard).
-    """
-    guard_x = max(16.0, _ALIGN_MAX_SHIFT_FRAC * full_w)
-    guard_y = max(16.0, _ALIGN_MAX_SHIFT_FRAC * full_h)
+def _shift_is_pathological(dx: float, dy: float, full_w: int, full_h: int) -> bool:
+    """Last-resort absolute sanity ceiling — a shift larger than half the
+    frame's own dimension isn't a plausible pass-to-pass drift regardless of
+    correlation confidence. Judges each axis against its own dimension (a
+    tall crop/strip window can have a legitimately large dy relative to its
+    narrow width, and vice versa for a wide window)."""
+    guard_x = _ALIGN_SANITY_MAX_FRAC * full_w
+    guard_y = _ALIGN_SANITY_MAX_FRAC * full_h
     return abs(dx) > guard_x or abs(dy) > guard_y
 
 
 def estimate_pass_shift(reference: np.ndarray, moving: np.ndarray) -> Shift2D:
-    """Estimate ``(dx, dy)`` (sub-pixel when OpenCV is available) for ``moving`` → ``reference``."""
+    """Estimate ``(dx, dy)`` (sub-pixel when OpenCV is available) for ``moving`` → ``reference``.
+
+    Trusts the phase-correlation peak's own sharpness (response), not shift
+    magnitude, to decide whether to use the result — see
+    ``_ALIGN_MIN_RESPONSE``. Real hardware drift on this platform is
+    routinely large (tens of px); a magnitude-based cutoff rejected real,
+    correctable shifts no matter how it was scaled to the frame.
+    """
     if not opencv_align_available():
         warn_if_align_unavailable("pass")
         return (0.0, 0.0)
@@ -163,18 +181,26 @@ def estimate_pass_shift(reference: np.ndarray, moving: np.ndarray) -> Shift2D:
     ref_lum = _luminance_plane(ref)
     mov_lum = _luminance_plane(mov)
     scale = max(1.0, full_w / _ALIGN_PROBE_WIDTH)
-    dx, dy = _phase_correlate_shift(ref_lum, mov_lum, scale=scale)
-    if _shift_exceeds_guard(dx, dy, full_w, full_h):
+    dx, dy, resp = _phase_correlate_shift(ref_lum, mov_lum, scale=scale)
+    if resp < _ALIGN_MIN_RESPONSE:
         logger.warning(
-            "pass_align: shift (%.2f, %.2f) exceeds guard — using unaligned",
+            "pass_align: shift (%.2f, %.2f) has low peak response (%.3f) — using unaligned",
+            dx,
+            dy,
+            resp,
+        )
+        return (0.0, 0.0)
+    if _shift_is_pathological(dx, dy, full_w, full_h):
+        logger.warning(
+            "pass_align: shift (%.2f, %.2f) exceeds sanity ceiling — using unaligned",
             dx,
             dy,
         )
         return (0.0, 0.0)
     dx, dy = _refine_pass_shift(ref, mov, (dx, dy))
-    if _shift_exceeds_guard(dx, dy, full_w, full_h):
+    if _shift_is_pathological(dx, dy, full_w, full_h):
         logger.warning(
-            "pass_align: refined shift (%.2f, %.2f) exceeds guard — using unaligned",
+            "pass_align: refined shift (%.2f, %.2f) exceeds sanity ceiling — using unaligned",
             dx,
             dy,
         )
@@ -300,7 +326,7 @@ def _band_shift_profile(
     Splits the frame into ``n_bands`` horizontal strips, phase-correlates
     each independently, and fits a line across the trustworthy bands' row
     centers instead of trusting one whole-frame shift. Bands below
-    ``_ALIGN_BAND_MIN_RESPONSE`` peak sharpness (too little local texture to
+    ``_ALIGN_MIN_RESPONSE`` peak sharpness (too little local texture to
     trust) are dropped before fitting; one more outlier band is dropped and
     the line refit if the initial fit's worst residual exceeds
     ``_ALIGN_BAND_OUTLIER_PX``, so a single aliased/low-texture band can't
@@ -313,9 +339,7 @@ def _band_shift_profile(
     trustworthy peak to fit a line at all. Callers should fall back to
     :func:`estimate_pass_shift` in that case.
     """
-    try:
-        import cv2
-    except ImportError:
+    if not opencv_align_available():
         return None
     ref = np.asarray(reference)
     mov = np.asarray(moving)
@@ -332,15 +356,12 @@ def _band_shift_profile(
         y1 = h if i == n_bands - 1 else y0 + band_h
         ref_lum = _luminance_plane(ref[y0:y1])
         mov_lum = _luminance_plane(mov[y0:y1])
-        win = cv2.createHanningWindow((ref_lum.shape[1], ref_lum.shape[0]), cv2.CV_32F)
-        (dx, dy), resp = cv2.phaseCorrelate(
-            np.ascontiguousarray(mov_lum), np.ascontiguousarray(ref_lum), win
-        )
-        if resp < _ALIGN_BAND_MIN_RESPONSE:
+        dx, dy, resp = _phase_correlate_shift(ref_lum, mov_lum, scale=scale)
+        if resp < _ALIGN_MIN_RESPONSE:
             continue  # too little texture in this band to trust its peak
         centers.append((y0 + y1) / 2.0)
-        dxs.append(dx * scale)
-        dys.append(dy * scale)
+        dxs.append(dx)
+        dys.append(dy)
     if len(centers) < max(3, n_bands // 2):
         return None
     c = np.asarray(centers, dtype=np.float64)

--- a/src/pyopticfilm/pass_align.py
+++ b/src/pyopticfilm/pass_align.py
@@ -19,6 +19,17 @@ _ALIGN_MAX_SHIFT_FRAC = 0.02
 _REFINE_ROI_SIDE = 2048
 _REFINE_MAX_RESIDUAL = 2.0
 
+# Row-banded alignment (see align_pass_to_reference_banded): a tall pass can
+# drift progressively along the feed axis rather than by one constant
+# offset (near-pure Y-axis drift, worse at high DPI/long feeds — see
+# jboneng/pyopticfilm#33), so a single whole-frame shift under- or
+# over-corrects depending on how far a region sits from wherever the
+# dominant texture anchored the estimate.
+_ALIGN_BAND_COUNT = 8
+_ALIGN_BAND_MIN_HEIGHT = 256  # below this, banding has too little signal per band
+_ALIGN_BAND_MIN_RESPONSE = 0.05  # cv2.phaseCorrelate's own peak-sharpness score
+_ALIGN_BAND_OUTLIER_PX = 8.0
+
 Shift2D = tuple[float, float]
 
 _cv2_warned = False
@@ -123,6 +134,22 @@ def _refine_pass_shift(
     return dx0 + ddx, dy0 + ddy
 
 
+def _shift_exceeds_guard(dx: float, dy: float, full_w: int, full_h: int) -> bool:
+    """True when ``dx``/``dy`` looks like a bogus phase-correlation result.
+
+    Each axis is checked against its own dimension — a tall crop/strip window
+    can have a legitimately large vertical drift relative to its (narrow)
+    width, and a wide window can have a legitimately large horizontal drift
+    relative to its (short) height. Judging both axes off a single
+    width-derived guard rejects real, correctable shifts on non-square
+    windows (e.g. a 1096x6700 strip crop, where a ~200px real dy is only
+    ~3% of height but ~9x a width-derived guard).
+    """
+    guard_x = max(16.0, _ALIGN_MAX_SHIFT_FRAC * full_w)
+    guard_y = max(16.0, _ALIGN_MAX_SHIFT_FRAC * full_h)
+    return abs(dx) > guard_x or abs(dy) > guard_y
+
+
 def estimate_pass_shift(reference: np.ndarray, moving: np.ndarray) -> Shift2D:
     """Estimate ``(dx, dy)`` (sub-pixel when OpenCV is available) for ``moving`` → ``reference``."""
     if not opencv_align_available():
@@ -132,12 +159,12 @@ def estimate_pass_shift(reference: np.ndarray, moving: np.ndarray) -> Shift2D:
     mov = np.asarray(moving)
     if ref.shape[:2] != mov.shape[:2]:
         return (0.0, 0.0)
-    full_w = ref.shape[1]
+    full_h, full_w = ref.shape[:2]
     ref_lum = _luminance_plane(ref)
     mov_lum = _luminance_plane(mov)
     scale = max(1.0, full_w / _ALIGN_PROBE_WIDTH)
     dx, dy = _phase_correlate_shift(ref_lum, mov_lum, scale=scale)
-    if max(abs(dx), abs(dy)) > max(16.0, _ALIGN_MAX_SHIFT_FRAC * full_w):
+    if _shift_exceeds_guard(dx, dy, full_w, full_h):
         logger.warning(
             "pass_align: shift (%.2f, %.2f) exceeds guard — using unaligned",
             dx,
@@ -145,7 +172,7 @@ def estimate_pass_shift(reference: np.ndarray, moving: np.ndarray) -> Shift2D:
         )
         return (0.0, 0.0)
     dx, dy = _refine_pass_shift(ref, mov, (dx, dy))
-    if max(abs(dx), abs(dy)) > max(16.0, _ALIGN_MAX_SHIFT_FRAC * full_w):
+    if _shift_exceeds_guard(dx, dy, full_w, full_h):
         logger.warning(
             "pass_align: refined shift (%.2f, %.2f) exceeds guard — using unaligned",
             dx,
@@ -263,6 +290,189 @@ def align_pass_to_reference(
     if abs(dx) < 1e-9 and abs(dy) < 1e-9:
         return mov, (0.0, 0.0)
     return _warp_shift(mov, dx, dy), (dx, dy)
+
+
+def _band_shift_profile(
+    reference: np.ndarray, moving: np.ndarray, *, n_bands: int = _ALIGN_BAND_COUNT
+) -> tuple[float, np.ndarray] | None:
+    """Per-row-band ``(dx, dy)`` estimate fit to a per-row ``dy(y)`` line.
+
+    Splits the frame into ``n_bands`` horizontal strips, phase-correlates
+    each independently, and fits a line across the trustworthy bands' row
+    centers instead of trusting one whole-frame shift. Bands below
+    ``_ALIGN_BAND_MIN_RESPONSE`` peak sharpness (too little local texture to
+    trust) are dropped before fitting; one more outlier band is dropped and
+    the line refit if the initial fit's worst residual exceeds
+    ``_ALIGN_BAND_OUTLIER_PX``, so a single aliased/low-texture band can't
+    skew the whole profile.
+
+    Returns ``(dx, dy_per_row)`` — a single representative dx (this
+    hardware's drift is near-pure Y-axis; see the module docstring) and a
+    length-``h`` array of the fitted dy for every row — or ``None`` when the
+    frame is too short to band usefully, or too few bands produced a
+    trustworthy peak to fit a line at all. Callers should fall back to
+    :func:`estimate_pass_shift` in that case.
+    """
+    try:
+        import cv2
+    except ImportError:
+        return None
+    ref = np.asarray(reference)
+    mov = np.asarray(moving)
+    h, w = ref.shape[:2]
+    if h < n_bands * _ALIGN_BAND_MIN_HEIGHT:
+        return None
+    band_h = h // n_bands
+    scale = max(1.0, w / _ALIGN_PROBE_WIDTH)
+    centers: list[float] = []
+    dxs: list[float] = []
+    dys: list[float] = []
+    for i in range(n_bands):
+        y0 = i * band_h
+        y1 = h if i == n_bands - 1 else y0 + band_h
+        ref_lum = _luminance_plane(ref[y0:y1])
+        mov_lum = _luminance_plane(mov[y0:y1])
+        win = cv2.createHanningWindow((ref_lum.shape[1], ref_lum.shape[0]), cv2.CV_32F)
+        (dx, dy), resp = cv2.phaseCorrelate(
+            np.ascontiguousarray(mov_lum), np.ascontiguousarray(ref_lum), win
+        )
+        if resp < _ALIGN_BAND_MIN_RESPONSE:
+            continue  # too little texture in this band to trust its peak
+        centers.append((y0 + y1) / 2.0)
+        dxs.append(dx * scale)
+        dys.append(dy * scale)
+    if len(centers) < max(3, n_bands // 2):
+        return None
+    c = np.asarray(centers, dtype=np.float64)
+    d = np.asarray(dys, dtype=np.float64)
+    slope, intercept = np.polyfit(c, d, 1)
+    resid = np.abs(d - (slope * c + intercept))
+    if len(c) > 3 and resid.max() > _ALIGN_BAND_OUTLIER_PX:
+        keep = resid < resid.max()
+        if keep.sum() >= 3:
+            slope, intercept = np.polyfit(c[keep], d[keep], 1)
+    dy_per_row = slope * np.arange(h, dtype=np.float64) + intercept
+    # Sanity floor: a fitted drift spanning more than half the frame's own
+    # height across the pass isn't a physically plausible feed drift — more
+    # likely a bad fit through mostly-untrustworthy bands. Fall back rather
+    # than apply it.
+    if float(np.max(dy_per_row) - np.min(dy_per_row)) > 0.5 * h:
+        return None
+    return float(np.median(dxs)), dy_per_row
+
+
+def _fill_row_shift_border(out: np.ndarray, dx: float, dy_per_row: np.ndarray) -> np.ndarray:
+    """Per-row generalization of :func:`_fill_shift_border`.
+
+    Any row whose source (``y - dy_per_row[y]``) sampled outside
+    ``[0, h-1]`` pulled in ``BORDER_CONSTANT`` padding from
+    :func:`_warp_row_shifts` — replace it with the nearest valid row's
+    content instead, same rationale as the constant-shift version.
+    """
+    h, w = out.shape[:2]
+    result = np.array(out, copy=True)
+    bx = int(np.ceil(abs(float(dx))))
+    if 0 < bx < w:
+        if dx > 0:
+            result[:, :bx] = result[:, bx : bx + 1]
+        else:
+            result[:, w - bx :] = result[:, w - bx - 1 : w - bx]
+    src_y = np.arange(h, dtype=np.float64) - dy_per_row
+    valid_rows = np.flatnonzero((src_y >= 0) & (src_y <= h - 1))
+    if valid_rows.size and valid_rows.size < h:
+        first_valid, last_valid = valid_rows[0], valid_rows[-1]
+        if first_valid > 0:
+            result[:first_valid] = result[first_valid]
+        if last_valid < h - 1:
+            result[last_valid + 1 :] = result[last_valid]
+    return result
+
+
+def _warp_row_shifts(mov: np.ndarray, dx: float, dy_per_row: np.ndarray) -> np.ndarray:
+    """Like :func:`_warp_shift` but with a per-row dy instead of one constant
+    shift for the whole frame — requires OpenCV (callers only reach this
+    once :func:`_band_shift_profile` has already required it)."""
+    import cv2
+
+    h, w = mov.shape[:2]
+    map_x = np.broadcast_to((np.arange(w, dtype=np.float32) - dx), (h, w)).copy()
+    map_y = np.broadcast_to(
+        (np.arange(h, dtype=np.float32) - dy_per_row.astype(np.float32))[:, np.newaxis], (h, w)
+    ).copy()
+    if mov.ndim == 3:
+        planes = [
+            cv2.remap(
+                mov[:, :, c],
+                map_x,
+                map_y,
+                interpolation=cv2.INTER_LINEAR,
+                borderMode=cv2.BORDER_CONSTANT,
+                borderValue=0,
+            )
+            for c in range(mov.shape[2])
+        ]
+        out = np.stack(planes, axis=2)
+    else:
+        out = cv2.remap(
+            mov,
+            map_x,
+            map_y,
+            interpolation=cv2.INTER_LINEAR,
+            borderMode=cv2.BORDER_CONSTANT,
+            borderValue=0,
+        )
+    if np.issubdtype(mov.dtype, np.integer):
+        out = np.clip(np.rint(out), 0, np.iinfo(mov.dtype).max).astype(mov.dtype)
+    else:
+        out = out.astype(mov.dtype, copy=False)
+    return _fill_row_shift_border(out, dx, dy_per_row)
+
+
+def align_pass_to_reference_banded(
+    reference: np.ndarray, moving: np.ndarray
+) -> tuple[np.ndarray, Shift2D]:
+    """Row-banded generalization of :func:`align_pass_to_reference`.
+
+    Fits a per-row ``dy(y)`` profile (see :func:`_band_shift_profile`)
+    instead of one whole-frame rigid shift, so progressive/non-rigid drift
+    along a tall pass is corrected across the whole frame instead of only
+    wherever the dominant texture happened to anchor a single global
+    estimate (real hardware repro: mid-frame content near the anchor came
+    out sharp while top/bottom — far from it — still ghosted, even after
+    accepting a whole-frame shift).
+
+    Falls back to the whole-frame :func:`align_pass_to_reference` (and its
+    existing guard) when the frame is too short to band usefully, or when
+    too few bands produced a trustworthy peak to fit a line.
+
+    Returns the warped array and ``(dx, dy_at_center)`` — a representative
+    single shift pair for logging/debug display, even though the actual
+    per-row correction varies along the frame.
+    """
+    if not opencv_align_available():
+        warn_if_align_unavailable("banded pass")
+        return align_pass_to_reference(reference, moving)
+    ref = np.asarray(reference)
+    mov = np.asarray(moving)
+    if mov.size == 0 or ref.shape[:2] != mov.shape[:2]:
+        return mov, (0.0, 0.0)
+    profile = _band_shift_profile(ref, mov)
+    if profile is None:
+        return align_pass_to_reference(ref, mov)
+    dx, dy_per_row = profile
+    h = ref.shape[0]
+    if abs(dx) < 1e-9 and float(np.max(np.abs(dy_per_row))) < 1e-9:
+        return mov, (0.0, 0.0)
+    warped = _warp_row_shifts(mov, dx, dy_per_row)
+    dy_lo, dy_hi = float(dy_per_row[0]), float(dy_per_row[-1])
+    logger.info(
+        "pass_align: banded profile dx=%.2f dy(row)=%.2f..%.2f (slope=%.4f px/row)",
+        dx,
+        dy_lo,
+        dy_hi,
+        (dy_hi - dy_lo) / max(1, h - 1),
+    )
+    return warped, (dx, float(dy_per_row[h // 2]))
 
 
 def align_ir_to_rgb(rgb: np.ndarray, ir: np.ndarray) -> np.ndarray:

--- a/src/pyopticfilm/scan/exposure_merge.py
+++ b/src/pyopticfilm/scan/exposure_merge.py
@@ -437,11 +437,36 @@ def merge_n_exposures(
     equivalent of the pairwise "pick short or long, whichever is more
     trusted" fallback).
 
-    Misalignment edge fallback: when both the worst per-bracket luma
-    disagreement and the merged IVW's cross-channel spread exceed their
-    thresholds (fringing from residual sub-pixel misregistration), the pixel
-    falls back to ``frames[0]`` verbatim — same thresholds and shape as the
-    2-way merge's ``misaligned`` gate.
+    Misalignment edge fallback: when the worst per-bracket luma disagreement
+    exceeds its threshold, the pixel falls back to ``frames[0]`` verbatim.
+    Deliberately luma-only — no cross-channel-spread requirement, unlike the
+    2-way merge's ``misaligned`` gate (which ANDs in a spread check — see
+    :func:`_merge_snr_rows`, kept as-is to preserve the ``n_brackets == 2``
+    production path's byte-identical guarantee). Measured empirically on
+    both directions of this tradeoff:
+
+    - Requiring cross-channel spread too (the 2-way gate's AND) misses real
+      Y-axis drift on flat/neutral-toned content (skin, cream fabric — see
+      jboneng/pyopticfilm#33 for independently measured Y-only drift on
+      this hardware): misregistered-but-neutral pixels disagree badly in
+      luminance but stay close to grey either way, so the AND never fires
+      and the ghosting blends straight through — the original real-hardware
+      bug this function's fallback is meant to catch.
+    - OR-ing spread in instead (rather than dropping it) is *worse*: any
+      saturated, well-aligned color patch has ``max(R,G,B)-min(R,G,B)``
+      far above ``_IVW_CHANNEL_SPREAD_TAU`` from real scene color alone —
+      verified on a synthetic well-aligned RGB-patch scene, where OR-gating
+      made every pixel fall back to ``frames[0]``, i.e. no fusion at all.
+    - Luma disagreement alone reproduced neither failure in the same
+      checks: ~0% false-trigger on a well-aligned saturated-color scene and
+      a well-aligned sharp achromatic edge, ~100% correct-trigger on a
+      genuinely 5px-drifted neutral gradient.
+
+    So N=2 through this function is *not* bit-for-bit against
+    :func:`_merge_snr_rows` on frames where the dropped spread condition
+    would have mattered — the N=2 equivalence documented above is, in
+    general, only for the confidence/IVW arithmetic itself (see
+    ``test_merge_n_exposures_two_frames_matches_pairwise_ivw``).
 
     Frames must already be pairwise-aligned to ``frames[0]`` by the caller
     (e.g. via repeated :func:`pyopticfilm.pass_align.align_pass_to_reference`
@@ -547,8 +572,9 @@ def merge_n_exposures(
         prefer = np.take_along_axis(x_stack, best_idx[np.newaxis, ...], axis=0)[0]
 
         merged = c_res_eff[..., np.newaxis] * ivw + (1.0 - c_res_eff[..., np.newaxis]) * prefer
-        ivw_spread = np.max(ivw, axis=2) - np.min(ivw, axis=2)
-        misaligned = (lum_diff_max > _LUMA_DISAGREE_TAU) & (ivw_spread > _IVW_CHANNEL_SPREAD_TAU)
+        # Luma disagreement alone — no cross-channel spread requirement, see
+        # the misalignment-edge-fallback docstring above.
+        misaligned = lum_diff_max > _LUMA_DISAGREE_TAU
         chunk = np.where(misaligned[..., np.newaxis], xs[0], merged)
         chunk = np.where(all_zero_conf, 0.0, chunk)
 

--- a/src/pyopticfilm/scan/session_gl128.py
+++ b/src/pyopticfilm/scan/session_gl128.py
@@ -390,7 +390,12 @@ class Gl128ScanSession(ScanSession):
         n_brackets: int = 2,
     ):
         from pyopticfilm.image import ScanImage
-        from pyopticfilm.pass_align import align_pass_to_reference, estimate_pass_shift, warn_if_align_unavailable
+        from pyopticfilm.pass_align import (
+            align_pass_to_reference,
+            align_pass_to_reference_banded,
+            estimate_pass_shift,
+            warn_if_align_unavailable,
+        )
         from pyopticfilm.scan.exposure_merge import merge_exposures_result, merge_n_exposures
         from pyopticfilm.scan.geometry import compute_geometry
         from pyopticfilm.scan.me_debug import BracketDebug, MeScanDebug
@@ -717,10 +722,19 @@ class Gl128ScanSession(ScanSession):
 
         align_shift_long: tuple[float, float] | None = None
         align_shift_ir: tuple[float, float] | None = None
+        # Model-gated: see Model8100V2.me_use_banded_alignment. Routes the
+        # 2-bracket path through the same row-banded alignment + luma-only
+        # misalignment gate already used for n_brackets > 2, instead of
+        # merge_exposures_result's whole-frame shift + AND-gated fallback.
+        # SE keeps the original byte-identical path (flag defaults False).
+        use_banded_me = n_brackets == 2 and bool(model.me_use_banded_alignment)
 
         if n_brackets == 2 and align_passes and rgb_long is not None:
             warn_if_align_unavailable("ME long")
-            align_shift_long = estimate_pass_shift(rgb_short, rgb_long)
+            if use_banded_me:
+                rgb_long, align_shift_long = align_pass_to_reference_banded(rgb_short, rgb_long)
+            else:
+                align_shift_long = estimate_pass_shift(rgb_short, rgb_long)
             logger.info(
                 "ME long pass shift (dx, dy)=(%.3f, %.3f)",
                 align_shift_long[0],
@@ -750,16 +764,24 @@ class Gl128ScanSession(ScanSession):
         me_beta = float(model.me_noise_beta)
 
         if multi_exposure and n_brackets == 2 and rgb_long is not None:
-            shift = align_shift_long if align_passes else (0.0, 0.0)
-            merged = merge_exposures_result(
-                rgb_short,
-                rgb_long,
-                exposure_short=exp_short,
-                exposure_long=exp_long,
-                align_shift=shift,
-                alpha=me_alpha,
-                beta=me_beta,
-            )
+            if use_banded_me:
+                # rgb_long is already banded-aligned above (or untouched if
+                # align_passes was False, matching the non-banded path's own
+                # "no alignment requested" semantics).
+                merged = merge_n_exposures(
+                    [rgb_short, rgb_long], [exp_short, exp_long], alpha=me_alpha, beta=me_beta
+                )
+            else:
+                shift = align_shift_long if align_passes else (0.0, 0.0)
+                merged = merge_exposures_result(
+                    rgb_short,
+                    rgb_long,
+                    exposure_short=exp_short,
+                    exposure_long=exp_long,
+                    align_shift=shift,
+                    alpha=me_alpha,
+                    beta=me_beta,
+                )
             primary = merged.rgb
             fusion_stats = merged.fusion_stats
             self.last_me_debug = MeScanDebug(
@@ -778,18 +800,23 @@ class Gl128ScanSession(ScanSession):
                 ],
             )
         elif multi_exposure and n_brackets > 2 and bracket_planes:
-            # Align every non-short bracket to rgb_short individually (same
-            # function used for the single long bracket above, looped), then
+            # Align every non-short bracket to rgb_short individually, then
             # fuse with the N-way IVW generalization — see exposure_merge.py::
             # merge_n_exposures, which also carries the residual-disagreement
             # gate and misalignment fallback from the 2-way merge.
+            #
+            # Uses the row-banded estimator (not the single whole-frame
+            # align_pass_to_reference used by the 2-bracket path above) —
+            # these are typically the tallest passes (crop/strip windows),
+            # where drift can vary along the pass rather than being one
+            # constant offset; see align_pass_to_reference_banded.
             frames = [rgb_short]
             exposures = [exp_short]
             bracket_debugs = [BracketDebug(rgb=rgb_short, exposure=exp_short, align_shift=None)]
             for e, rgb in bracket_planes:
                 if align_passes:
                     warn_if_align_unavailable("ME bracket")
-                    warped, shift = align_pass_to_reference(rgb_short, rgb)
+                    warped, shift = align_pass_to_reference_banded(rgb_short, rgb)
                 else:
                     warped, shift = rgb, None
                 frames.append(warped)

--- a/tests/test_gl128_siblings.py
+++ b/tests/test_gl128_siblings.py
@@ -63,6 +63,8 @@ def test_divergent_fields_match_capture_catalog():
     assert MODEL_8100_V2.use_slow_final_positioning_feed is True
     assert MODEL_8200I_SE.me_default_exposure_mode == "adaptive"
     assert MODEL_8100_V2.me_default_exposure_mode == "fixed"
+    assert MODEL_8200I_SE.me_use_banded_alignment is False
+    assert MODEL_8100_V2.me_use_banded_alignment is True
     assert MODEL_8200I_SE.lperiod_by_dpi[7200] == 15963
     assert MODEL_8100_V2.lperiod_by_dpi[7200] == 16035
     assert dict(MODEL_8200I_SE.max_image_lincnt_by_feed2) == {

--- a/tests/test_manual_exposure.py
+++ b/tests/test_manual_exposure.py
@@ -8,6 +8,8 @@ clamp; an explicitly supplied value is written to ``REG_EXPOSURE`` verbatim.
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from pyopticfilm.device.model_8100_v2 import MODEL_8100_V2
@@ -402,6 +404,45 @@ def test_n_brackets_default_matches_two_bracket_debug():
     assert len(debug.brackets) == 2
     assert debug.brackets[0].exposure == debug.exposure_short
     assert debug.brackets[-1].exposure == debug.exposure_long
+
+
+def test_two_bracket_v2_routes_through_banded_luma_only_merge():
+    """Model8100V2.me_use_banded_alignment routes n_brackets==2 through
+    merge_n_exposures (banded alignment + luma-only misalignment gate),
+    not merge_exposures_result's whole-frame-shift + AND-gated path."""
+    from pyopticfilm.scan import exposure_merge
+
+    session, _usb = _mock_gl128_session_armed_for(MODEL_8100_V2)
+    with (
+        patch.object(
+            exposure_merge, "merge_n_exposures", wraps=exposure_merge.merge_n_exposures
+        ) as spy_n,
+        patch.object(
+            exposure_merge, "merge_exposures_result", wraps=exposure_merge.merge_exposures_result
+        ) as spy_pairwise,
+    ):
+        session.run(resolution=1800, area=_TINY, apply_calib=False, multi_exposure=True)
+    assert spy_n.call_count == 1
+    assert spy_pairwise.call_count == 0
+
+
+def test_two_bracket_se_keeps_original_pairwise_merge():
+    """SE (me_use_banded_alignment=False) is unaffected — still routes
+    n_brackets==2 through merge_exposures_result, byte-identical."""
+    from pyopticfilm.scan import exposure_merge
+
+    session, _usb = _mock_gl128_session_armed()  # defaults to MODEL_8200I_SE
+    with (
+        patch.object(
+            exposure_merge, "merge_n_exposures", wraps=exposure_merge.merge_n_exposures
+        ) as spy_n,
+        patch.object(
+            exposure_merge, "merge_exposures_result", wraps=exposure_merge.merge_exposures_result
+        ) as spy_pairwise,
+    ):
+        session.run(resolution=1800, area=_TINY, apply_calib=False, multi_exposure=True)
+    assert spy_pairwise.call_count == 1
+    assert spy_n.call_count == 0
 
 
 def test_n_brackets_five_captures_five_ascending_exposures():

--- a/tests/test_me.py
+++ b/tests/test_me.py
@@ -335,14 +335,16 @@ def test_align_pass_subpixel_shift_when_opencv_available():
     assert abs(dy - (-2.0)) < 0.6
 
 
-def test_align_pass_tall_crop_accepts_large_dy_within_height_guard():
+def test_align_pass_tall_crop_accepts_large_dy():
     """A tall/narrow crop window (e.g. a multi-frame strip scan) can have a
     real, correctable dy that is small relative to frame height but large
-    relative to frame width — the guard must judge each axis against its
-    own dimension, not reject a real height-scale shift using a
-    width-derived threshold (regression for the 1096x6700 ghosting seen on
-    real 8100 V2 hardware, where a real dy=-195.81 was ~9x a width-only
-    guard but only ~3% of the frame's height)."""
+    relative to frame width — regression for the 1096x6700 ghosting seen on
+    real 8100 V2 hardware, where a real dy=-195.81 was rejected by an
+    axis-blind, magnitude-based guard. The current guard is response-based
+    (see test_align_pass_accepts_large_real_hardware_drift below for why
+    magnitude alone — even judged per-axis — still wasn't enough), so this
+    also stands as a same-shape check on a narrow/tall aspect ratio
+    specifically."""
     try:
         import cv2  # noqa: F401
     except ImportError:
@@ -350,15 +352,75 @@ def test_align_pass_tall_crop_accepts_large_dy_within_height_guard():
     from pyopticfilm.pass_align import align_pass_to_reference, estimate_pass_shift
 
     rng = np.random.default_rng(2)
-    # Narrow, tall crop window, same aspect ratio ballpark as the repro
-    # (1096x6700). Height-derived guard = max(16, 0.02*1340) = 26.8;
-    # width-derived guard (the pre-fix behavior) = max(16, 0.02*220) = 16.
     base = rng.integers(1000, 20000, (1340, 220, 3), dtype=np.uint16)
-    # dy=20 clears the height guard (26.8) but would be rejected by a
-    # width-only guard (16) — the bug this test guards against.
     shifted, _ = align_pass_to_reference(base, base, shift=(0.0, 20.0))
     _dx, dy = estimate_pass_shift(base, shifted)
     assert abs(dy - 20.0) < 1.0, f"real height-scale dy was rejected: got dy={dy}"
+
+
+def test_align_pass_accepts_large_real_hardware_drift():
+    """Regression for the second round of ghosting: a completely ordinary
+    1712x1201 full-frame 1200dpi scan (not a tall crop) on real 8100 V2
+    hardware measured a real ~30px drift that a magnitude-based guard
+    rejected even after the per-axis fix above (guard_y = max(16,
+    0.02*1201) = 24.02, still below the real ~30px shift). #33's own
+    benchmark independently measured real drift up to ~42px on this
+    hardware, so any magnitude-based cutoff scaled off frame dimensions
+    fights real behavior. The guard is now response-based (trusts the
+    phase-correlation peak's own sharpness, not the shift's size) —
+    verify a large, but well-correlated, shift on an ordinary-aspect frame
+    is no longer rejected."""
+    try:
+        import cv2  # noqa: F401
+    except ImportError:
+        return
+    from pyopticfilm.pass_align import align_pass_to_reference, estimate_pass_shift
+
+    rng = np.random.default_rng(6)
+    base = rng.integers(1000, 20000, (1201, 1712, 3), dtype=np.uint16)
+    shifted, _ = align_pass_to_reference(base, base, shift=(-0.09, -29.98))
+    dx, dy = estimate_pass_shift(base, shifted)
+    # Sign follows this module's existing convention (see other tests in
+    # this file) — what matters here is that the real ~30px magnitude
+    # survives instead of being rejected down to (0, 0).
+    assert abs(dx) < 1.0
+    assert abs(abs(dy) - 29.98) < 1.0, f"real large drift was rejected: got dy={dy}"
+
+
+def test_align_pass_rejects_bogus_lock_on_uncorrelated_content():
+    """The response-based guard must reject an untrustworthy peak — the
+    exact failure mode a magnitude-only guard can't catch at all (a bogus
+    shift can be any size, including one that looks plausible) and the
+    reason jboneng/pyopticfilm#14 saw an occasional bogus lock on
+    low-texture content. Two fully independent noise frames have nothing
+    real to correlate on; phase correlation still reports *some* shift
+    (there's always a max in the cross-power spectrum), but with a weak,
+    unreliable response — verified directly below — that must be rejected
+    regardless of how large or small the reported shift happens to be."""
+    try:
+        import cv2  # noqa: F401
+    except ImportError:
+        return
+    from pyopticfilm.pass_align import (
+        _ALIGN_MIN_RESPONSE,
+        _luminance_plane,
+        _phase_correlate_shift,
+        estimate_pass_shift,
+    )
+
+    rng = np.random.default_rng(9)
+    ref = rng.integers(0, 65535, (256, 256, 3), dtype=np.uint32).astype(np.uint16)
+    mov = rng.integers(0, 65535, (256, 256, 3), dtype=np.uint32).astype(np.uint16)
+
+    _dx, _dy, resp = _phase_correlate_shift(
+        _luminance_plane(ref), _luminance_plane(mov), scale=1.0
+    )
+    assert resp < _ALIGN_MIN_RESPONSE, f"test setup didn't reproduce a weak peak: resp={resp}"
+
+    dx, dy = estimate_pass_shift(ref, mov)
+    assert dx == 0.0 and dy == 0.0, (
+        f"uncorrelated content's bogus lock should be rejected, got ({dx}, {dy})"
+    )
 
 
 # --- N-bracket merge (merge_n_exposures) ----------------------------------

--- a/tests/test_me.py
+++ b/tests/test_me.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from pyopticfilm.device.model_8200i_se import MODEL_8200I_SE
-from pyopticfilm.pass_align import align_pass_to_reference
+from pyopticfilm.pass_align import align_pass_to_reference, align_pass_to_reference_banded
 from pyopticfilm.scan.exposure_merge import (
     merge_exposures,
     merge_exposures_result,
@@ -335,16 +335,46 @@ def test_align_pass_subpixel_shift_when_opencv_available():
     assert abs(dy - (-2.0)) < 0.6
 
 
+def test_align_pass_tall_crop_accepts_large_dy_within_height_guard():
+    """A tall/narrow crop window (e.g. a multi-frame strip scan) can have a
+    real, correctable dy that is small relative to frame height but large
+    relative to frame width — the guard must judge each axis against its
+    own dimension, not reject a real height-scale shift using a
+    width-derived threshold (regression for the 1096x6700 ghosting seen on
+    real 8100 V2 hardware, where a real dy=-195.81 was ~9x a width-only
+    guard but only ~3% of the frame's height)."""
+    try:
+        import cv2  # noqa: F401
+    except ImportError:
+        return
+    from pyopticfilm.pass_align import align_pass_to_reference, estimate_pass_shift
+
+    rng = np.random.default_rng(2)
+    # Narrow, tall crop window, same aspect ratio ballpark as the repro
+    # (1096x6700). Height-derived guard = max(16, 0.02*1340) = 26.8;
+    # width-derived guard (the pre-fix behavior) = max(16, 0.02*220) = 16.
+    base = rng.integers(1000, 20000, (1340, 220, 3), dtype=np.uint16)
+    # dy=20 clears the height guard (26.8) but would be rejected by a
+    # width-only guard (16) — the bug this test guards against.
+    shifted, _ = align_pass_to_reference(base, base, shift=(0.0, 20.0))
+    _dx, dy = estimate_pass_shift(base, shifted)
+    assert abs(dy - 20.0) < 1.0, f"real height-scale dy was rejected: got dy={dy}"
+
+
 # --- N-bracket merge (merge_n_exposures) ----------------------------------
 
 
 def test_merge_n_exposures_two_frames_matches_pairwise_ivw():
-    """N=2 must reduce exactly to the pairwise merge's arithmetic, including
-    the residual-disagreement gate and misalignment fallback (there is
-    exactly one non-reference bracket at N=2, so merge_n_exposures's
-    per-bracket loop collapses to _merge_snr_rows's wa/wb/ivw/c_res_eff/
-    prefer/misaligned terms directly — verified in exposure_merge.py's
-    docstring and during development).
+    """N=2 must reduce exactly to the pairwise merge's confidence/IVW
+    arithmetic (there is exactly one non-reference bracket at N=2, so
+    merge_n_exposures's per-bracket loop collapses to _merge_snr_rows's
+    wa/wb/ivw/c_res_eff/prefer terms directly). The misalignment *fallback*
+    is deliberately NOT required to match: merge_n_exposures uses a
+    luma-only gate (see its docstring) while _merge_snr_rows still ANDs in
+    a cross-channel-spread check, kept as-is for the n_brackets==2
+    production path's byte-identical guarantee. Neither of this test's
+    synthetic scenes exercises that specific divergence (no real
+    misregistration is introduced here), so the two still agree below.
 
     Not bit-for-bit against merge_exposures_result: that function additionally
     estimates the *actual* image-fit exposure ratio via
@@ -382,6 +412,115 @@ def test_merge_n_exposures_two_frames_matches_pairwise_ivw():
     assert result_u.fusion_stats.mean_residual_confidence == pytest.approx(
         pairwise_u.fusion_stats.mean_residual_confidence, abs=1e-4
     )
+
+
+def test_merge_n_exposures_misalign_gate_is_luma_only_not_chroma_spread():
+    """Regression for the ghosting seen on real 8100 V2 hardware (skin/cream
+    fabric ghosted while the high-chroma striped strap stayed sharp).
+
+    Two real-hardware-shaped failure modes, both wrong, ruled out here:
+
+    - AND-ing in cross-channel spread (the original 2-way gate's shape)
+      misses genuine misregistration on neutral/flat-toned content: a real
+      luma disagreement there doesn't move R/G/B apart from each other, so
+      the AND never fires and the ghost blends straight through.
+    - OR-ing spread in instead (rather than dropping it) is worse: any
+      well-aligned saturated color patch has max(R,G,B)-min(R,G,B) far
+      above the spread threshold from real scene color alone, so OR-gating
+      makes *every* pixel fall back to frames[0] — no fusion at all, even
+      with zero real misalignment.
+
+    Luma-only avoids both: near-untouched fusion on a well-aligned,
+    saturated-color scene, and a near-total fallback-to-frames[0] on a
+    genuinely drifted neutral gradient (protecting it from ghosting)."""
+    rng = np.random.default_rng(3)
+    h, w = 64, 64
+
+    # Well-aligned, saturated RGB patches — must NOT collapse to frames[0].
+    truth = np.zeros((h, w, 3), dtype=np.float64)
+    truth[:, : w // 3] = [40000, 4000, 4000]
+    truth[:, w // 3 : 2 * w // 3] = [4000, 40000, 4000]
+    truth[:, 2 * w // 3 :] = [4000, 4000, 40000]
+    truth += rng.normal(0, 200, truth.shape)
+    short = np.clip(truth / 3.0, 0, 65535).astype(np.uint16)
+    long = np.clip(truth, 0, 65535).astype(np.uint16)
+    colorful_result = merge_n_exposures([short, long], [14000, 42000])
+    assert colorful_result.fusion_stats is not None
+    assert colorful_result.fusion_stats.mean_residual_confidence > 0.9, (
+        "well-aligned saturated color incorrectly triggered the misalignment fallback"
+    )
+
+    # Genuinely drifted (5px), low-chroma (near-neutral) gradient — MUST
+    # fall back to frames[0] rather than ghost.
+    grad = np.linspace(5000, 50000, h)[:, None, None] * np.ones((1, w, 3))
+    grad += rng.normal(0, 100, grad.shape)
+    short_n = np.clip(grad / 3.0, 0, 65535).astype(np.uint16)
+    long_n = np.roll(np.clip(grad, 0, 65535).astype(np.uint16), 5, axis=0)
+    neutral_result = merge_n_exposures([short_n, long_n], [14000, 42000])
+    diff_from_short = np.abs(
+        neutral_result.rgb.astype(np.float64) - short_n.astype(np.float64)
+    ).mean()
+    assert diff_from_short < 5.0, (
+        f"drifted neutral content was not protected by the misalignment fallback "
+        f"(mean diff from frames[0]: {diff_from_short})"
+    )
+
+
+def test_align_pass_to_reference_banded_recovers_progressive_drift():
+    """A tall pass with drift that grows along the feed axis (not a constant
+    offset) — the real-hardware shape of the bug: mid-frame content near
+    wherever the whole-frame estimate anchored came out sharp, while
+    top/bottom (far from it) still ghosted even after applying that single
+    global shift. Row-banded alignment should track the profile and leave
+    a small residual at both ends, not just in the middle."""
+    try:
+        import cv2  # noqa: F401
+    except ImportError:
+        return
+
+    rng = np.random.default_rng(5)
+    h, w = 2400, 300
+    # Strong texture throughout so every band has a trustworthy peak.
+    base = rng.integers(1000, 40000, (h, w, 3), dtype=np.uint16).astype(np.float64)
+
+    # True per-row drift: linear from 0px (top) to 40px (bottom) — a
+    # progressive feed slip, not one rigid shift.
+    true_dy = np.linspace(0.0, 40.0, h)
+    row_idx = np.clip(np.arange(h) - np.round(true_dy).astype(int), 0, h - 1)
+    moving = base[row_idx].astype(np.uint16)
+    reference = base.astype(np.uint16)
+
+    warped, (dx, dy_center) = align_pass_to_reference_banded(reference, moving)
+    assert abs(dx) < 1.0
+    # Profile's midpoint should be ~half the total 40px drift (sign follows
+    # this module's existing shift convention, verified by the residual
+    # checks below rather than assumed here).
+    assert abs(abs(dy_center) - 20.0) < 3.0
+
+    # Compare against the whole-frame rigid alignment on the same pair — it
+    # can only fit one number for the entire frame, so it necessarily
+    # favors wherever that number happens to be closest to correct (the
+    # real-hardware bug: sharp near the anchor, still ghosted far from it).
+    whole_frame, _ = align_pass_to_reference(reference, moving)
+
+    def _residual(a, b, y0, y1):
+        return np.abs(
+            a[y0:y1].astype(np.float64) - b[y0:y1].astype(np.float64)
+        ).mean()
+
+    band = 200
+    top_whole = _residual(reference, whole_frame, 0, band)
+    bottom_whole = _residual(reference, whole_frame, h - band, h)
+    top_banded = _residual(reference, warped, 0, band)
+    bottom_banded = _residual(reference, warped, h - band, h)
+
+    # Row-banded must beat whole-frame rigid at BOTH extremes. (This
+    # particular profile is symmetric around the frame's midpoint, so a
+    # single global shift lands close to the average and is similarly
+    # wrong at both ends rather than trading one off against the other —
+    # banded still tracks the true per-row drift and clearly outperforms.)
+    assert top_banded < 0.75 * top_whole, (top_whole, top_banded)
+    assert bottom_banded < 0.75 * bottom_whole, (bottom_whole, bottom_banded)
 
 
 def test_merge_n_exposures_validates_frame_count():


### PR DESCRIPTION
## What this does

Three bugs found while wiring #1041 (NegPy) up against this branch and testing N-Exposure ME on real 8100 V2 hardware, plus one deliberate extension:

1. **Per-axis alignment guard** — `pass_align.py`'s sanity check judged both dx and dy against a width-derived threshold. A tall crop/strip window (e.g. 1096x6700) can have a real, correctable dy that's small relative to height but large relative to width — a legitimate shift was being rejected outright (`shift ... exceeds guard — using unaligned`). Now judges each axis against its own dimension.
2. **Row-banded alignment** — even fixed, a single whole-frame rigid shift can't correct drift that varies along a tall pass. Content near wherever the global phase-correlation estimate anchored came out sharp; content far from it (e.g. the top/bottom of a strip scan) stayed ghosted. Added `align_pass_to_reference_banded`: phase-correlates independent row bands, fits a line across the trustworthy ones, warps per-row.
3. **Luma-only misalignment fallback** — `merge_n_exposures`'s fallback required both a luma disagreement *and* a cross-channel spread anomaly (AND) before dropping a pixel back to `frames[0]`. Real Y-drift on flat/neutral-toned content (skin, cream fabric) disagrees in luminance without moving the spread, so it never fired and ghosting blended straight through. I first tried loosening to OR — that's *worse*: verified empirically that any well-aligned saturated-color patch already exceeds the spread threshold from real scene color alone, so OR made *every* pixel fall back (no fusion at all). Luma alone is correct: near-zero false-trigger on well-aligned color/achromatic content, reliable trigger on genuine drift.
4. **Extended to 8100 V2's 2-bracket path** — same ghosting confirmed on 2x ME on real hardware, not just N>2. Gated behind a new `Model8100V2.me_use_banded_alignment` flag (`True` on V2 only, same pattern as `me_default_exposure_mode`) so 8200i SE's 2-bracket path stays byte-identical/untouched — this hasn't been confirmed on SE hardware.

## Why software, not hardware

The root Y-axis jitter is a real, open, unsolved hardware/firmware characteristic of the GL128 positioning system on the 8100 V2 — #33's benchmark independently measured 1-40+px near-pure-Y drift between scans, worse at high DPI, only partially mitigated by priming. This PR doesn't fix that; it makes the ME pipeline robust *to* it: correct the drift where it can be measured (row-banded), and never blend ghosting into the output where it can't (luma-only fallback). #14's history shows the same shape of problem before (phase correlation occasionally locking onto a bogus shift on low-texture content) — this continues that thread rather than reopening it from scratch.

## Validation

- `pytest -q`: 365 passed, 1 skipped (0 regressions)
- `pytest -m model_lock`: 75 passed (0 regressions)
- `tests/test_gl128_siblings.py`: 7 passed
- New tests: per-axis guard regression, banded-vs-whole-frame comparison, luma-only-vs-AND/OR gate regression (all three failure shapes reproduced and checked), routing test confirming V2 goes through the new path and SE doesn't
- **Real 8100 V2 hardware:** single-pass, 2x ME, and 3-pass ME all confirmed by hand
- Draft-tested end-to-end against marcinz606/NegPy#1041, which depends on this branch's API surface

## Scope

Doesn't touch #33 itself (the underlying jitter) or #50 (the separate N=5 color-balance-near-ceiling issue) — both out of scope here, noted for anyone tracking them.