### PR TITLE
Forensic tab: slope-table/feed-timing/register milestones + timeline spans

### DIFF
--- a/tools/scanlab/README.md
+++ b/tools/scanlab/README.md
@@ -216,7 +216,18 @@ per model or shared across the GL128 family). Sub-pages:
 - **Live timeline** — plain-text scrolling log of every decoded USB event.
 - **Timeline** — a graphical, colour-lane timeline (per event kind) with
   click-to-inspect; the Event Inspector shows raw bytes, decoded fields,
-  and the matching register's catalog meaning together.
+  and the matching register's catalog meaning together. A legend above the
+  graph explains every lane colour, the anomaly severity markers, and the
+  feed-timing span colour. Below the axis, duration brackets mark each
+  positioning feed — labelled with the slope table actually uploaded for it
+  (**FAST**/**SLOW**/**CUSTOM**, identified by comparing the raw AHB upload
+  payload byte-for-byte against the known tables) and how long the motor was
+  enabled for that feed — above a Motor/Lamp on-off state band. A toolbar
+  label reports the run's total recorded duration. A **Known/Unknown
+  values** panel alongside the graph lists every distinct register value
+  the run touched (slope table per feed, LPERIOD, EXPOSURE, pixel clock)
+  next to any register addresses seen with no catalog entry to explain
+  them, so unrecognized traffic stays visible instead of silently dropped.
 - **Reference** — every known status bit and register, filterable, rows
   coloured by confidence; a register flagged with a hardware-safety note
   (e.g. the FEEDL positioning-feed slope tables, or the 8100 V2 feed-probe
@@ -225,7 +236,9 @@ per model or shared across the GL128 family). Sub-pages:
   Timeline tab and reports how many events in the currently loaded run
   reference that register.
 - **Run browser** — saved run list, baseline/compare, milestones and
-  anomalies for a selected run, and Wireshark/USBPcap import.
+  anomalies for a selected run, and Wireshark/USBPcap import. The exported
+  AI bug report includes a **Positioning & timing** section listing the
+  feed-timing, LPERIOD, EXPOSURE, and pixel-clock milestones for the run.
 
 Regenerate the standalone markdown catalog (`docs/register-reference.md`)
 with `python -m tools.register_reference` after editing the catalog.

--- a/tools/scanlab/app.py
+++ b/tools/scanlab/app.py
@@ -95,7 +95,7 @@ class ScanLabWindow(QMainWindow):
 
         self.run_mock = QCheckBox("Run against MOCK")
         self.run_mock.setChecked(True)
-        self.run_mock.toggled.connect(self._refresh_banner)
+        self.run_mock.toggled.connect(self._on_run_mock_toggled)
         form.addWidget(self.run_mock)
 
         self.override_hw_gate = QCheckBox("Override safety HW gate")
@@ -375,6 +375,11 @@ class ScanLabWindow(QMainWindow):
             self.ir_pass.setChecked(False)
         is_gl128 = getattr(target.model, "asic", "") == "GL128"
         self.me_pass.setEnabled(is_gl128)
+        was_connected = getattr(self.forensic_tab, "_is_connected", False)
+        self._worker.close_scanner()
+        self._refresh_banner()
+        if was_connected:
+            self._on_forensic_connect()
         if not is_gl128:
             self.me_pass.setChecked(False)
         self.me_fixed_long.setEnabled(is_gl128 and self.me_pass.isChecked())
@@ -639,6 +644,18 @@ class ScanLabWindow(QMainWindow):
         self._refresh_banner()
         if self._capture is not None:
             self._decode_loaded_capture()
+
+    def _on_run_mock_toggled(self, _checked: bool) -> None:
+        # A stale open Scanner/RecordingTransport (real or mock) would
+        # otherwise linger until the next Prescan/Scan/Forensic-connect
+        # happens to notice the LabTarget.mock mismatch - close it now so
+        # the banner and, if Forensic-connected, the live session/badge
+        # follow the toggle immediately in both directions.
+        was_connected = getattr(self.forensic_tab, "_is_connected", False)
+        self._worker.close_scanner()
+        self._refresh_banner()
+        if was_connected:
+            self._on_forensic_connect()
 
     def _on_open_capture(self) -> None:
         path, _ = QFileDialog.getOpenFileName(

--- a/tools/scanlab/forensic_milestones.py
+++ b/tools/scanlab/forensic_milestones.py
@@ -27,8 +27,11 @@ import json
 from pathlib import Path
 from typing import Any
 
+from pyopticfilm.asic.gl128 import _u16_table_bytes
 from pyopticfilm.asic.registers import Gl128Registers
-from tools.scanlab.forensic_event_inspector import load_decoded_events
+from pyopticfilm.device.tables_8200i_se import SLOPE_TABLE_FAST, SLOPE_TABLE_SLOW
+from tools.scanlab.forensic_event_inspector import _read_jsonl, load_decoded_events
+from tools.scanlab.forensic_reference import explain_register
 from tools.scanlab.forensic_timecode import format_timecode
 
 _R = Gl128Registers()
@@ -37,6 +40,26 @@ _R = Gl128Registers()
 REG_FEEDL_ADDRS = {hex(_R.REG_FEEDL), hex(_R.REG_FEEDL + 1), hex(_R.REG_FEEDL + 2)}
 REG_LAMP = hex(_R.REG_0x03)
 LAMPPWR = _R.LAMPPWR
+REG_LPERIOD_ADDRS = {hex(_R.REG_LPERIOD), hex(_R.REG_LPERIOD + 1), hex(_R.REG_LPERIOD + 2)}
+REG_EXPOSURE_ADDRS = {hex(_R.REG_EXPOSURE), hex(_R.REG_EXPOSURE + 1), hex(_R.REG_EXPOSURE + 2)}
+#: Pixel-clock singles (clk_a/clk_b, see Gl128.run_asic_shading) - not a
+#: 24-bit field like LPERIOD/EXPOSURE, each byte stands alone.
+PIXEL_CLOCK_ADDRS = {hex(0xA5), hex(0xAB)}
+AHB_SLOPE_ADDRS = {hex(_R.AHB_SLOPE_SCAN), hex(_R.AHB_SLOPE_FAST)}
+_SLOPE_FAST_BYTES = _u16_table_bytes(SLOPE_TABLE_FAST)
+_SLOPE_SLOW_BYTES = _u16_table_bytes(SLOPE_TABLE_SLOW)
+#: 0x101 status register, MOTORENB bit (see forensic_anomaly.py's
+#: motor_enabled_prolonged rule - same bit, reused here for feed timing).
+MOTORENB = 0x01
+#: Max events to search forward from a FEEDL write for its slope-table
+#: upload and motor-enabled start/end - keeps an irrelevant small feed
+#: (e.g. a per-line feed during image acquisition) from pairing with an
+#: unrelated, much-later motor-enabled span.
+_FEED_SEARCH_WINDOW = 1000
+#: Smallest FEEDL treated as a real positioning move for feed-timing
+#: purposes (observed real feeds are thousands of steps; smaller values
+#: seen in traffic are incidental resets during image acquisition).
+_MIN_POSITIONING_FEEDL = 500
 
 
 def _registers_at(events: list[dict[str, Any]], upto_index: int) -> dict[str, int]:
@@ -58,6 +81,133 @@ def _hex24(regs: dict[str, int], hi: int) -> int | None:
     return (a << 16) | (b << 8) | c
 
 
+def _motor_enabled(value: Any) -> bool | None:
+    if not isinstance(value, int):
+        return None
+    return bool(value & MOTORENB)
+
+
+def _slope_table_for_upload(
+    decoded_events: list[dict[str, Any]], raw_events: list[dict[str, Any]], preamble_idx: int
+) -> str | None:
+    """Identify FAST/SLOW/CUSTOM for an AHB slope-table upload at
+    ``decoded_events[preamble_idx]`` by comparing the following bulk_out's
+    raw payload (same index in usb_raw.jsonl - the two files are 1:1, same
+    order, per forensic_event_inspector.py) against the two known tables.
+    None when there's no matching bulk_out or no raw payload available
+    (e.g. an imported Wireshark run with no usb_raw.jsonl)."""
+    j = preamble_idx + 1
+    if j >= len(decoded_events) or decoded_events[j].get("kind") != "bulk_out":
+        return None
+    if j >= len(raw_events):
+        return None
+    data_hex = raw_events[j].get("data")
+    if not data_hex:
+        return None
+    payload = bytes.fromhex(data_hex)
+    if payload == _SLOPE_FAST_BYTES:
+        return "FAST"
+    if payload == _SLOPE_SLOW_BYTES:
+        return "SLOW"
+    return "CUSTOM"
+
+
+def _build_feed_timing_milestones(
+    decoded_events: list[dict[str, Any]], raw_events: list[dict[str, Any]], t_first: float | None
+) -> list[dict[str, Any]]:
+    """One milestone per positioning feed: which slope table was uploaded
+    for it, and how long the motor was actually enabled (0x101 MOTORENB)
+    for that feed - the same span the motor_enabled_prolonged anomaly
+    rule watches, here attributed to a specific feed instead of flagged
+    as an anomaly in isolation."""
+    milestones: list[dict[str, Any]] = []
+    last_feedl: int | None = None
+
+    for idx, ev in enumerate(decoded_events):
+        if ev.get("kind") != "reg_write":
+            continue
+        regs_before = _registers_at(decoded_events, idx - 1)
+        for pair in ev.get("fields", {}).get("pairs", []):
+            addr, val = pair["addr"], pair["value"]
+            if addr not in REG_FEEDL_ADDRS:
+                continue
+            merged = dict(regs_before)
+            merged[addr] = val
+            feedl = _hex24(merged, 0x3D)
+            # feedl == 1 is the documented "no additional feed" convention
+            # (see gl128.py); values under _MIN_POSITIONING_FEEDL are small
+            # incidental resets seen during image acquisition, not a real
+            # positioning move - both would otherwise pair with an unrelated
+            # motor-enabled span and report a bogus duration.
+            if feedl is None or feedl == 1 or feedl < _MIN_POSITIONING_FEEDL or feedl == last_feedl:
+                continue
+            last_feedl = feedl
+
+            table = None
+            for j in range(idx + 1, min(len(decoded_events), idx + 60)):
+                e2 = decoded_events[j]
+                if e2.get("kind") == "buffer_preamble" and e2.get("fields", {}).get("bulk_addr") in AHB_SLOPE_ADDRS:
+                    table = _slope_table_for_upload(decoded_events, raw_events, j)
+                    break
+
+            # Bounded so a feed with no plausible motor-enabled window nearby
+            # (e.g. a per-line feed during image acquisition, not a real
+            # positioning move) can't pair with an unrelated, much-later
+            # motor-enabled span and report a bogus multi-second duration.
+            search_end = min(len(decoded_events), idx + _FEED_SEARCH_WINDOW)
+            start_idx = next(
+                (
+                    j
+                    for j in range(idx + 1, search_end)
+                    if decoded_events[j].get("kind") == "reg_read"
+                    and decoded_events[j].get("fields", {}).get("addr") == "0x101"
+                    and _motor_enabled(decoded_events[j].get("fields", {}).get("value"))
+                ),
+                None,
+            )
+            if start_idx is None:
+                continue
+            end_idx = next(
+                (
+                    j
+                    for j in range(start_idx + 1, search_end)
+                    if decoded_events[j].get("kind") == "reg_read"
+                    and decoded_events[j].get("fields", {}).get("addr") == "0x101"
+                    and _motor_enabled(decoded_events[j].get("fields", {}).get("value")) is False
+                ),
+                None,
+            )
+            if end_idx is None:
+                continue
+
+            t0_start = decoded_events[start_idx].get("raw_t0")
+            t0_end = decoded_events[end_idx].get("raw_t0")
+            if t0_start is None or t0_end is None:
+                continue
+            duration_s = t0_end - t0_start
+            rel_s = (t0_start - t_first) if t_first is not None else None
+            table_label = table or "unknown (no raw payload)"
+            milestones.append(
+                {
+                    "index": idx,
+                    "t0": t0_start,
+                    "rel_s": rel_s,
+                    "kind": "feed_timing",
+                    "label": f"Positioning feed FEEDL={feedl}: {table_label} table, {duration_s:.2f}s",
+                    "confidence": "STRONG" if table else "LIKELY",
+                    "evidence": {
+                        "feedl": feedl,
+                        "slope_table": table,
+                        "start_rel_s": rel_s,
+                        "end_rel_s": (t0_end - t_first) if t_first is not None else None,
+                        "duration_s": round(duration_s, 3),
+                    },
+                }
+            )
+
+    return milestones
+
+
 def _classify_preamble(w_index: str, bulk_size: int) -> tuple[str, str]:
     """Returns (label, confidence)."""
     if w_index == "0x8":
@@ -71,19 +221,30 @@ def _classify_preamble(w_index: str, bulk_size: int) -> tuple[str, str]:
     return f"unclassified w_index={w_index}", "UNKNOWN"
 
 
-def build_milestones(decoded_events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def build_milestones(
+    decoded_events: list[dict[str, Any]], raw_events: list[dict[str, Any]] | None = None
+) -> list[dict[str, Any]]:
     """One milestone per meaningful state change - not every raw event.
 
     Each milestone: {index, t0, rel_s, kind, label, confidence, evidence}.
     ``rel_s`` is seconds since the first event that has a timestamp (t0);
     None for sources without per-event timing (a plain pcap import without
     per-packet timestamps still gets index-ordered milestones).
+
+    ``raw_events`` (usb_raw.jsonl, same index/order as ``decoded_events`` -
+    see forensic_event_inspector.py) is optional and only needed to
+    identify which slope table (FAST/SLOW/CUSTOM) a positioning feed used;
+    without it, feed-timing milestones still appear but with an "unknown"
+    table (e.g. for an imported Wireshark run with no raw payloads).
     """
     t_first = next((e.get("raw_t0") for e in decoded_events if e.get("raw_t0") is not None), None)
     milestones: list[dict[str, Any]] = []
 
     last_lamp: int | None = None
     last_feedl: int | None = None
+    last_lperiod: int | None = None
+    last_exposure: int | None = None
+    last_pixel_clock: dict[str, int] = {}
 
     for idx, ev in enumerate(decoded_events):
         t0 = ev.get("raw_t0")
@@ -143,12 +304,65 @@ def build_milestones(decoded_events: list[dict[str, Any]]) -> list[dict[str, Any
                             "evidence": {"value": hex(val)},
                         }
                     )
+                if addr in REG_LPERIOD_ADDRS:
+                    merged = dict(regs_before)
+                    merged[addr] = val
+                    lperiod = _hex24(merged, _R.REG_LPERIOD)
+                    if lperiod is not None and lperiod != last_lperiod:
+                        last_lperiod = lperiod
+                        meaning = explain_register(hex(_R.REG_LPERIOD), lperiod)
+                        milestones.append(
+                            {
+                                "index": idx,
+                                "t0": t0,
+                                "rel_s": rel_s,
+                                "kind": "lperiod",
+                                "label": f"LPERIOD={lperiod}" + (f" ({meaning})" if meaning else ""),
+                                "confidence": "STRONG",
+                                "evidence": {"lperiod": lperiod},
+                            }
+                        )
+                if addr in REG_EXPOSURE_ADDRS:
+                    merged = dict(regs_before)
+                    merged[addr] = val
+                    exposure = _hex24(merged, _R.REG_EXPOSURE)
+                    if exposure is not None and exposure != last_exposure:
+                        last_exposure = exposure
+                        meaning = explain_register(hex(_R.REG_EXPOSURE), exposure)
+                        milestones.append(
+                            {
+                                "index": idx,
+                                "t0": t0,
+                                "rel_s": rel_s,
+                                "kind": "exposure",
+                                "label": f"EXPOSURE={exposure}" + (f" ({meaning})" if meaning else ""),
+                                "confidence": "STRONG",
+                                "evidence": {"exposure": exposure},
+                            }
+                        )
+                if addr in PIXEL_CLOCK_ADDRS and last_pixel_clock.get(addr) != val:
+                    last_pixel_clock[addr] = val
+                    which = "clk_a" if addr == hex(0xA5) else "clk_b"
+                    meaning = explain_register(addr, val)
+                    milestones.append(
+                        {
+                            "index": idx,
+                            "t0": t0,
+                            "rel_s": rel_s,
+                            "kind": "pixel_clock",
+                            "label": f"Pixel clock {which} ({addr})={val}" + (f" ({meaning})" if meaning else ""),
+                            "confidence": "STRONG",
+                            "evidence": {which: val},
+                        }
+                    )
 
+    milestones.extend(_build_feed_timing_milestones(decoded_events, raw_events or [], t_first))
+    milestones.sort(key=lambda m: (m["index"], m["kind"]))
     return milestones
 
 
 def build_milestones_for_run(run_dir: Path) -> list[dict[str, Any]]:
-    return build_milestones(load_decoded_events(run_dir))
+    return build_milestones(load_decoded_events(run_dir), _read_jsonl(run_dir / "usb_raw.jsonl"))
 
 
 def _collapse_repeats(milestones: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/tools/scanlab/forensic_milestones.py
+++ b/tools/scanlab/forensic_milestones.py
@@ -119,8 +119,17 @@ def _build_feed_timing_milestones(
     for it, and how long the motor was actually enabled (0x101 MOTORENB)
     for that feed - the same span the motor_enabled_prolonged anomaly
     rule watches, here attributed to a specific feed instead of flagged
-    as an anomaly in isolation."""
-    milestones: list[dict[str, Any]] = []
+    as an anomaly in isolation.
+
+    A single physical feed's 24-bit FEEDL is written one byte at a time,
+    so ``_hex24`` sees several distinct intermediate values (e.g. 13057
+    then 13128) for what is really one feed - all reconstructing to the
+    same motor-enabled window. Keyed by that window (``start_idx, end_idx``)
+    and overwritten as later, more-complete byte writes are seen, so only
+    the final value survives instead of emitting one overlapping
+    duplicate span per intermediate write.
+    """
+    milestones: dict[tuple[int, int], dict[str, Any]] = {}
     last_feedl: int | None = None
 
     for idx, ev in enumerate(decoded_events):
@@ -187,25 +196,23 @@ def _build_feed_timing_milestones(
             duration_s = t0_end - t0_start
             rel_s = (t0_start - t_first) if t_first is not None else None
             table_label = table or "unknown (no raw payload)"
-            milestones.append(
-                {
-                    "index": idx,
-                    "t0": t0_start,
-                    "rel_s": rel_s,
-                    "kind": "feed_timing",
-                    "label": f"Positioning feed FEEDL={feedl}: {table_label} table, {duration_s:.2f}s",
-                    "confidence": "STRONG" if table else "LIKELY",
-                    "evidence": {
-                        "feedl": feedl,
-                        "slope_table": table,
-                        "start_rel_s": rel_s,
-                        "end_rel_s": (t0_end - t_first) if t_first is not None else None,
-                        "duration_s": round(duration_s, 3),
-                    },
-                }
-            )
+            milestones[(start_idx, end_idx)] = {
+                "index": idx,
+                "t0": t0_start,
+                "rel_s": rel_s,
+                "kind": "feed_timing",
+                "label": f"Positioning feed FEEDL={feedl}: {table_label} table, {duration_s:.2f}s",
+                "confidence": "STRONG" if table else "LIKELY",
+                "evidence": {
+                    "feedl": feedl,
+                    "slope_table": table,
+                    "start_rel_s": rel_s,
+                    "end_rel_s": (t0_end - t_first) if t_first is not None else None,
+                    "duration_s": round(duration_s, 3),
+                },
+            }
 
-    return milestones
+    return sorted(milestones.values(), key=lambda m: m["index"])
 
 
 def _classify_preamble(w_index: str, bulk_size: int) -> tuple[str, str]:
@@ -437,3 +444,84 @@ def format_milestones(
                 f"| {marker['label']} | {format_timecode(marker['rel_s'])} | {dur_s} | {details_s} |"
             )
     return "\n".join(lines)
+
+
+def derive_states(decoded_events: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Motor/lamp on-off transitions for the timeline's state lanes - same
+    bits as the feed-timing/lamp milestones above (0x101 MOTORENB, 0x03
+    LAMPPWR), exposed as a plain per-name transition list instead of a
+    milestone entry."""
+    t_first = next((e.get("raw_t0") for e in decoded_events if e.get("raw_t0") is not None), None)
+    motor: list[dict[str, Any]] = []
+    lamp: list[dict[str, Any]] = []
+    last_motor: bool | None = None
+    last_lamp_on: bool | None = None
+
+    for ev in decoded_events:
+        t0 = ev.get("raw_t0")
+        if t0 is None or t_first is None:
+            continue
+        rel_s = t0 - t_first
+        if ev.get("kind") == "reg_read" and ev.get("fields", {}).get("addr") == "0x101":
+            val = _motor_enabled(ev.get("fields", {}).get("value"))
+            if val is not None and val != last_motor:
+                last_motor = val
+                motor.append({"rel_s": rel_s, "value": val})
+        elif ev.get("kind") == "reg_write":
+            for pair in ev.get("fields", {}).get("pairs", []):
+                if pair["addr"] == REG_LAMP:
+                    lamp_on = bool(pair["value"] & LAMPPWR)
+                    if lamp_on != last_lamp_on:
+                        last_lamp_on = lamp_on
+                        lamp.append({"rel_s": rel_s, "value": lamp_on})
+
+    return {"Motor": motor, "Lamp": lamp}
+
+
+def collect_known_values(milestones: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Distinct known register/table values seen this run, each with its
+    first-seen timecode - the "don't make me scrub the timeline to find
+    this" summary. One row per distinct label within a kind (a value that
+    changes mid-run, e.g. two different feeds' slope tables, gets one row
+    each)."""
+    kinds = {"feed_timing", "lperiod", "exposure", "pixel_clock"}
+    seen: set[tuple[str, str]] = set()
+    out: list[dict[str, Any]] = []
+    for m in milestones:
+        if m["kind"] not in kinds:
+            continue
+        key = (m["kind"], m["label"])
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append({"kind": m["kind"], "label": m["label"], "rel_s": m.get("rel_s")})
+    return out
+
+
+def collect_unknown_registers(decoded_events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Distinct register addresses touched this run that
+    ``explain_register()`` has nothing to say about - an honest "we don't
+    know" list (matching that function's own convention) instead of
+    silently dropping unexplained traffic. One row per distinct address,
+    first-seen value and timecode."""
+    t_first = next((e.get("raw_t0") for e in decoded_events if e.get("raw_t0") is not None), None)
+    seen: set[str] = set()
+    out: list[dict[str, Any]] = []
+    for ev in decoded_events:
+        t0 = ev.get("raw_t0")
+        rel_s = (t0 - t_first) if (t0 is not None and t_first is not None) else None
+        kind = ev.get("kind")
+        fields = ev.get("fields", {})
+        pairs = []
+        if kind == "reg_write":
+            pairs = [(p["addr"], p["value"]) for p in fields.get("pairs", [])]
+        elif kind == "reg_read" and fields.get("addr"):
+            pairs = [(fields["addr"], fields.get("value"))]
+        for addr, value in pairs:
+            if addr in seen:
+                continue
+            if explain_register(addr, value) is not None:
+                continue
+            seen.add(addr)
+            out.append({"addr": addr, "value": value, "rel_s": rel_s})
+    return out

--- a/tools/scanlab/forensic_report_export.py
+++ b/tools/scanlab/forensic_report_export.py
@@ -42,8 +42,9 @@ def build_ai_report(run_dir: Path, *, baseline_dir: Path | None = None) -> str:
     result = _load_json(run_dir / "result.json")
     decoded_events = _load_jsonl(run_dir / "decoded_events.jsonl")
     phase_markers = _load_jsonl(run_dir / "phase_markers.jsonl")
+    raw_events = _load_jsonl(run_dir / "usb_raw.jsonl")
 
-    milestones = build_milestones(decoded_events)
+    milestones = build_milestones(decoded_events, raw_events)
     anomalies = detect_anomalies(decoded_events, phase_markers=phase_markers)
 
     env = manifest.get("environment", {})
@@ -91,7 +92,16 @@ def build_ai_report(run_dir: Path, *, baseline_dir: Path | None = None) -> str:
     else:
         lines.append("(no phase markers recorded for this run)")
 
+    timing_kinds = {"feed_timing", "lperiod", "exposure", "pixel_clock"}
+    timing_milestones = [m for m in milestones if m["kind"] in timing_kinds]
     lines += [
+        "",
+        "## Positioning & timing",
+        (
+            format_milestones(timing_milestones, collapse_repeats=False)
+            if timing_milestones
+            else "(no positioning-feed or timing-register milestones found)"
+        ),
         "",
         "## Anomalies",
         format_anomalies(anomalies),

--- a/tools/scanlab/forensic_tab.py
+++ b/tools/scanlab/forensic_tab.py
@@ -844,9 +844,29 @@ class ForensicTabPage(QWidget):
 
         # Also drive the graphical Timeline tab + Event Inspector for this
         # run - post-hoc, whole-run render (as opposed to the live append_*
-        # path used while a Session is still active).
+        # path used while a Session is still active). Feed-timing milestones
+        # become duration brackets; register-value milestones become plain
+        # markers alongside the host-side phase markers.
+        feed_spans = [
+            {
+                "start_rel_s": m["evidence"].get("start_rel_s"),
+                "end_rel_s": m["evidence"].get("end_rel_s"),
+                "label": m["label"],
+            }
+            for m in milestones
+            if m["kind"] == "feed_timing"
+            and m["evidence"].get("start_rel_s") is not None
+            and m["evidence"].get("end_rel_s") is not None
+        ]
+        register_markers = [
+            {"rel_s": m["rel_s"], "label": m["label"]}
+            for m in milestones
+            if m["kind"] in ("lperiod", "exposure", "pixel_clock") and m.get("rel_s") is not None
+        ]
         self._inspector_run_dir = run_dir
-        self.timeline_graph.set_data(decoded_events, phase_markers, anomalies)
+        self.timeline_graph.set_data(
+            decoded_events, (phase_markers or []) + register_markers, anomalies, feed_spans
+        )
 
     @staticmethod
     def _read_decoded_events(run_dir: Path) -> list[dict]:

--- a/tools/scanlab/forensic_tab.py
+++ b/tools/scanlab/forensic_tab.py
@@ -52,7 +52,13 @@ from tools.register_reference import parse_addr
 from tools.scanlab.forensic_anomaly import detect_anomalies, format_anomalies
 from tools.scanlab.forensic_diff import first_divergence, format_divergence
 from tools.scanlab.forensic_event_inspector import format_event, load_decoded_events, load_event
-from tools.scanlab.forensic_milestones import build_milestones_for_run, format_milestones
+from tools.scanlab.forensic_milestones import (
+    build_milestones_for_run,
+    collect_known_values,
+    collect_unknown_registers,
+    derive_states,
+    format_milestones,
+)
 from tools.scanlab.forensic_pcap_import import import_pcap
 from tools.scanlab.forensic_reference import (
     KNOWN_REGISTERS,
@@ -63,7 +69,8 @@ from tools.scanlab.forensic_reference import (
 )
 from tools.scanlab.forensic_report_export import build_ai_report
 from tools.scanlab.forensic_session import export_run_zip, get_baseline, list_runs, set_baseline
-from tools.scanlab.forensic_timeline_view import TimelineGraphView
+from tools.scanlab.forensic_timeline_view import TimelineGraphView, legend_html
+from tools.scanlab.forensic_values_panel import ValuesPanel
 
 _IDLE_STOP_MS = 1000  # auto-record: stop this long after traffic goes idle
 
@@ -272,7 +279,7 @@ class ForensicTabPage(QWidget):
 
     def _build_timeline_graph_tab(self) -> QWidget:
         page = QWidget()
-        layout = QVBoxLayout(page)
+        outer = QVBoxLayout(page)
 
         toolbar = QHBoxLayout()
         btn_clear = QPushButton("Clear")
@@ -285,24 +292,68 @@ class ForensicTabPage(QWidget):
         toolbar.addWidget(btn_clear)
         toolbar.addWidget(btn_fit)
         toolbar.addWidget(btn_live)
+        self.timeline_duration_label = QLabel("Total: --")
+        toolbar.addWidget(self.timeline_duration_label)
         toolbar.addStretch(1)
         toolbar.addWidget(QLabel("Scroll to zoom, drag to pan, click a mark to inspect it below."))
-        layout.addLayout(toolbar)
+        outer.addLayout(toolbar)
+
+        legend = QLabel(legend_html())
+        legend.setStyleSheet("color: #444;")
+        outer.addWidget(legend)
+
+        timeline_col = QWidget()
+        layout = QVBoxLayout(timeline_col)
+        layout.setContentsMargins(0, 0, 0, 0)
 
         self.timeline_graph = TimelineGraphView()
         self.timeline_graph.event_selected.connect(self._on_timeline_event_selected)
-        layout.addWidget(self.timeline_graph, 2)
 
-        layout.addWidget(QLabel("Event Inspector — raw bytes, decoded fields, and register meaning together"))
+        inspector_col = QWidget()
+        inspector_layout = QVBoxLayout(inspector_col)
+        inspector_layout.setContentsMargins(0, 0, 0, 0)
+        inspector_layout.addWidget(QLabel("Event Inspector — raw bytes, decoded fields, and register meaning together"))
         self.event_inspector = QPlainTextEdit()
         self.event_inspector.setReadOnly(True)
         self.event_inspector.setPlaceholderText("Click a mark on the timeline above, or a milestone/anomaly row.")
-        layout.addWidget(self.event_inspector, 1)
+        inspector_layout.addWidget(self.event_inspector)
+
+        # setStretchFactor alone only governs how EXTRA space is distributed
+        # on resize, not the initial split - QSplitter defaults new children
+        # to equal sizes otherwise, which is what was silently overriding
+        # the intended timeline-heavy layout. setSizes() sets the initial
+        # split; the stretch factors above still apply to later resizes.
+        vertical_split = QSplitter(Qt.Orientation.Vertical)
+        vertical_split.addWidget(self.timeline_graph)
+        vertical_split.addWidget(inspector_col)
+        vertical_split.setStretchFactor(0, 5)
+        vertical_split.setStretchFactor(1, 1)
+        vertical_split.setSizes([900, 160])
+        layout.addWidget(vertical_split)
+
+        self.values_panel = ValuesPanel()
+        horizontal_split = QSplitter(Qt.Orientation.Horizontal)
+        horizontal_split.addWidget(timeline_col)
+        horizontal_split.addWidget(self.values_panel)
+        horizontal_split.setStretchFactor(0, 4)
+        horizontal_split.setStretchFactor(1, 1)
+        horizontal_split.setSizes([1200, 300])
+        # Stretch factor 1 here (vs. the toolbar/legend's implicit 0 above)
+        # means Qt gives ALL leftover vertical space to the splitter and
+        # leaves the toolbar/legend at their natural sizeHint - without
+        # this, QVBoxLayout divides leftover space roughly evenly across
+        # every item when all stretch factors are 0, which is what was
+        # inflating the toolbar and legend rows to ~1/3 of the tab's height
+        # each, squeezing the actual timeline into a sliver at the bottom.
+        outer.addWidget(horizontal_split, 1)
+        self.timeline_tab_page = page
         return page
 
     def _on_timeline_clear_clicked(self) -> None:
         self.timeline_graph.clear()
         self.event_inspector.clear()
+        self.values_panel.clear()
+        self.timeline_duration_label.setText("Total: --")
 
     def _on_timeline_event_selected(self, index: int) -> None:
         if self._inspector_run_dir is None:
@@ -415,8 +466,10 @@ class ForensicTabPage(QWidget):
         # Switch this Forensic tab's own right-hand tab widget to "Timeline"
         # (the caller — app.py's ScanLabWindow — has its own outer QTabWidget
         # with a "Forensic" tab; switching to that one, if needed, is the
-        # caller's responsibility, not this widget's).
-        idx = self.right_tabs.indexOf(self.timeline_graph.parentWidget())
+        # caller's responsibility, not this widget's). Uses the tab page
+        # itself, not timeline_graph.parentWidget() - the graph now sits
+        # inside a QSplitter, so its direct parent isn't the tab page.
+        idx = self.right_tabs.indexOf(self.timeline_tab_page)
         if idx >= 0:
             self.right_tabs.setCurrentIndex(idx)
         if self._inspector_run_dir is None:
@@ -487,8 +540,6 @@ class ForensicTabPage(QWidget):
         export_col = QVBoxLayout()
         self.btn_export_run = QPushButton("Export selected run (.zip)")
         self.btn_export_run.clicked.connect(self._on_export_run_clicked)
-        self.btn_export_detail = QPushButton("Export shown text…")
-        self.btn_export_detail.clicked.connect(self._on_export_detail_clicked)
         self.btn_export_ai_report = QPushButton("Export AI bug report…")
         self.btn_export_ai_report.setToolTip(
             "Bundles this run's summary, phase durations, milestones, and "
@@ -498,7 +549,6 @@ class ForensicTabPage(QWidget):
         )
         self.btn_export_ai_report.clicked.connect(self._on_export_ai_report_clicked)
         export_col.addWidget(self.btn_export_run)
-        export_col.addWidget(self.btn_export_detail)
         export_col.addWidget(self.btn_export_ai_report)
         list_col.addLayout(export_col)
 
@@ -845,28 +895,30 @@ class ForensicTabPage(QWidget):
         # Also drive the graphical Timeline tab + Event Inspector for this
         # run - post-hoc, whole-run render (as opposed to the live append_*
         # path used while a Session is still active). Feed-timing milestones
-        # become duration brackets; register-value milestones become plain
-        # markers alongside the host-side phase markers.
+        # become duration brackets; LPERIOD/EXPOSURE/pixel-clock values go to
+        # the Known-values panel instead of the timeline (that's what was
+        # crowding the marker row) - only host-side phase markers stay there.
         feed_spans = [
             {
                 "start_rel_s": m["evidence"].get("start_rel_s"),
                 "end_rel_s": m["evidence"].get("end_rel_s"),
-                "label": m["label"],
+                # Terser than the milestone's own label (which can be wider
+                # than a short span, overflowing into the next one) - the
+                # full "Positioning feed FEEDL=..." text is still in the
+                # Known-values panel and the text report.
+                "label": f"{m['evidence'].get('slope_table') or '?'} {m['evidence'].get('duration_s', 0):.2f}s",
             }
             for m in milestones
             if m["kind"] == "feed_timing"
             and m["evidence"].get("start_rel_s") is not None
             and m["evidence"].get("end_rel_s") is not None
         ]
-        register_markers = [
-            {"rel_s": m["rel_s"], "label": m["label"]}
-            for m in milestones
-            if m["kind"] in ("lperiod", "exposure", "pixel_clock") and m.get("rel_s") is not None
-        ]
+        states = derive_states(decoded_events)
         self._inspector_run_dir = run_dir
-        self.timeline_graph.set_data(
-            decoded_events, (phase_markers or []) + register_markers, anomalies, feed_spans
-        )
+        self.timeline_graph.set_data(decoded_events, phase_markers, anomalies, feed_spans, states)
+        duration = self.timeline_graph.total_duration_s()
+        self.timeline_duration_label.setText(f"Total: {duration:.2f}s" if duration is not None else "Total: --")
+        self.values_panel.set_data(collect_known_values(milestones), collect_unknown_registers(decoded_events))
 
     @staticmethod
     def _read_decoded_events(run_dir: Path) -> list[dict]:
@@ -927,19 +979,6 @@ class ForensicTabPage(QWidget):
             QMessageBox.warning(self, "Export run", f"Failed to export:\n{exc}")
             return
         self.append_timeline_line(f"[export] {run_dir} -> {dest}")
-
-    def _on_export_detail_clicked(self) -> None:
-        dest, _ = QFileDialog.getSaveFileName(
-            self, "Export shown text", "forensic_report.md", "Markdown (*.md);;Text (*.txt);;All files (*.*)"
-        )
-        if not dest:
-            return
-        try:
-            Path(dest).write_text(self.run_detail.toPlainText(), encoding="utf-8")
-        except OSError as exc:
-            QMessageBox.warning(self, "Export", f"Failed to write file:\n{exc}")
-            return
-        self.append_timeline_line(f"[export] shown text -> {dest}")
 
     def _on_export_ai_report_clicked(self) -> None:
         pair = self._selected_run_and_baseline()

--- a/tools/scanlab/forensic_timeline_view.py
+++ b/tools/scanlab/forensic_timeline_view.py
@@ -49,6 +49,8 @@ SEVERITY_COLORS = {"info": QColor("#888888"), "warning": QColor("#c07a20"), "cri
 _LANE_H = 22
 _TOP_MARGIN = 50  # room for rotated marker labels
 _AXIS_H = 24
+_SPAN_H = 16  # feed-timing / other duration brackets, between axis and lanes
+_SPAN_COLOR = QColor("#1f7a4d")
 
 
 def lane_for_kind(kind: str) -> str:
@@ -98,11 +100,12 @@ class TimelineGraphView(QWidget):
 
     def __init__(self) -> None:
         super().__init__()
-        self.setMinimumHeight(_TOP_MARGIN + _AXIS_H + _LANE_H * len(LANES) + 10)
+        self.setMinimumHeight(_TOP_MARGIN + _AXIS_H + _SPAN_H + _LANE_H * len(LANES) + 10)
         self.setMouseTracking(True)
         self._points: dict[str, list[tuple[float, int]]] = {lane: [] for lane in LANES}
         self._markers: list[tuple[float, str]] = []  # (rel_s, label)
         self._anomalies: list[tuple[float, str, int]] = []  # (rel_s, severity, index)
+        self._spans: list[tuple[float, float, str]] = []  # (start_s, end_s, label)
         self._t_data_min: float | None = None
         self._t_data_max: float | None = None
         self._t_view_min = 0.0
@@ -117,6 +120,7 @@ class TimelineGraphView(QWidget):
         self._points = {lane: [] for lane in LANES}
         self._markers = []
         self._anomalies = []
+        self._spans = []
         self._t_data_min = None
         self._t_data_max = None
         self._t_view_min = 0.0
@@ -129,6 +133,7 @@ class TimelineGraphView(QWidget):
         decoded_events: list[dict],
         phase_markers: list[dict] | None = None,
         anomalies: list | None = None,
+        spans: list[dict] | None = None,
     ) -> None:
         """Post-hoc: render a whole saved run at once. ``decoded_events``
         entries carry ``raw_t0`` (absolute perf_counter, from usb/decode.py)
@@ -151,6 +156,9 @@ class TimelineGraphView(QWidget):
             index = getattr(a, "index", None) if not isinstance(a, dict) else a.get("index")
             if rel_s is not None and index is not None:
                 self.append_anomaly(rel_s, severity or "info", index)
+        for s in spans or []:
+            if s.get("start_rel_s") is not None and s.get("end_rel_s") is not None:
+                self.append_span(s["start_rel_s"], s["end_rel_s"], s.get("label", ""))
         self._auto_follow = False
         self._fit_all()
 
@@ -170,6 +178,12 @@ class TimelineGraphView(QWidget):
     def append_anomaly(self, rel_s: float, severity: str, index: int) -> None:
         self._anomalies.append((rel_s, severity, index))
         self._extend_range(rel_s)
+        self.update()
+
+    def append_span(self, start_s: float, end_s: float, label: str) -> None:
+        self._spans.append((start_s, end_s, label))
+        self._extend_range(start_s)
+        self._extend_range(end_s)
         self.update()
 
     def _extend_range(self, t: float) -> None:
@@ -246,8 +260,27 @@ class TimelineGraphView(QWidget):
             painter.drawLine(QPointF(x, _TOP_MARGIN + _AXIS_H - 4), QPointF(x, _TOP_MARGIN + _AXIS_H))
             painter.drawText(QPointF(x + 2, _TOP_MARGIN + _AXIS_H - 6), format_timecode(t))
 
+        # spans: duration brackets (e.g. feed-timing) between the axis and lanes
+        span_y0 = _TOP_MARGIN + _AXIS_H
+        span_mid = span_y0 + _SPAN_H / 2
+        painter.setFont(QFont("", 7))
+        for start_s, end_s, label in self._spans:
+            if end_s < self._t_view_min or start_s > self._t_view_max:
+                continue
+            x1 = self._x_for_t(max(start_s, self._t_view_min), width)
+            x2 = self._x_for_t(min(end_s, self._t_view_max), width)
+            pen = QPen(_SPAN_COLOR)
+            pen.setWidth(2)
+            painter.setPen(pen)
+            painter.drawLine(QPointF(x1, span_mid), QPointF(x2, span_mid))
+            painter.drawLine(QPointF(x1, span_y0 + 2), QPointF(x1, span_y0 + _SPAN_H - 2))
+            painter.drawLine(QPointF(x2, span_y0 + 2), QPointF(x2, span_y0 + _SPAN_H - 2))
+            if label:
+                painter.setPen(_SPAN_COLOR)
+                painter.drawText(QPointF(x1 + 3, span_y0 + _SPAN_H - 4), label[:60])
+
         # lanes
-        lane_y0 = _TOP_MARGIN + _AXIS_H
+        lane_y0 = _TOP_MARGIN + _AXIS_H + _SPAN_H
         for li, lane in enumerate(LANES):
             y = lane_y0 + li * _LANE_H
             painter.setPen(QColor("#eeeeee"))

--- a/tools/scanlab/forensic_timeline_view.py
+++ b/tools/scanlab/forensic_timeline_view.py
@@ -51,10 +51,22 @@ _TOP_MARGIN = 50  # room for rotated marker labels
 _AXIS_H = 24
 _SPAN_H = 16  # feed-timing / other duration brackets, between axis and lanes
 _SPAN_COLOR = QColor("#1f7a4d")
+_STATE_NAMES = ["Motor", "Lamp"]  # fixed order/rows for the on/off state band
+_STATE_H = 14
+_STATE_COLOR = QColor("#3a6fa5")
 
 
 def lane_for_kind(kind: str) -> str:
     return _KIND_TO_LANE.get(kind, "unclassified")
+
+
+def legend_html() -> str:
+    """Rich-text legend for a QLabel placed above the timeline - answers
+    "what does this color/shape mean" without a tooltip or a click."""
+    chips = [f'<span style="color:{c.name()}">●</span> {name}' for name, c in LANE_COLORS.items()]
+    chips.append(f'<span style="color:{_SPAN_COLOR.name()}">━</span> feed timing')
+    chips += [f'<span style="color:{c.name()}">▲</span> {sev}' for sev, c in SEVERITY_COLORS.items()]
+    return "&nbsp;&nbsp;".join(chips)
 
 
 @dataclass
@@ -100,12 +112,15 @@ class TimelineGraphView(QWidget):
 
     def __init__(self) -> None:
         super().__init__()
-        self.setMinimumHeight(_TOP_MARGIN + _AXIS_H + _SPAN_H + _LANE_H * len(LANES) + 10)
+        self.setMinimumHeight(
+            _TOP_MARGIN + _AXIS_H + _SPAN_H + _STATE_H * len(_STATE_NAMES) + _LANE_H * len(LANES) + 10
+        )
         self.setMouseTracking(True)
         self._points: dict[str, list[tuple[float, int]]] = {lane: [] for lane in LANES}
         self._markers: list[tuple[float, str]] = []  # (rel_s, label)
         self._anomalies: list[tuple[float, str, int]] = []  # (rel_s, severity, index)
         self._spans: list[tuple[float, float, str]] = []  # (start_s, end_s, label)
+        self._states: dict[str, list[tuple[float, bool]]] = {name: [] for name in _STATE_NAMES}
         self._t_data_min: float | None = None
         self._t_data_max: float | None = None
         self._t_view_min = 0.0
@@ -121,6 +136,7 @@ class TimelineGraphView(QWidget):
         self._markers = []
         self._anomalies = []
         self._spans = []
+        self._states = {name: [] for name in _STATE_NAMES}
         self._t_data_min = None
         self._t_data_max = None
         self._t_view_min = 0.0
@@ -134,6 +150,7 @@ class TimelineGraphView(QWidget):
         phase_markers: list[dict] | None = None,
         anomalies: list | None = None,
         spans: list[dict] | None = None,
+        states: dict[str, list[dict]] | None = None,
     ) -> None:
         """Post-hoc: render a whole saved run at once. ``decoded_events``
         entries carry ``raw_t0`` (absolute perf_counter, from usb/decode.py)
@@ -159,6 +176,10 @@ class TimelineGraphView(QWidget):
         for s in spans or []:
             if s.get("start_rel_s") is not None and s.get("end_rel_s") is not None:
                 self.append_span(s["start_rel_s"], s["end_rel_s"], s.get("label", ""))
+        for name, changes in (states or {}).items():
+            for c in changes:
+                if c.get("rel_s") is not None and c.get("value") is not None:
+                    self.append_state_change(name, c["rel_s"], bool(c["value"]))
         self._auto_follow = False
         self._fit_all()
 
@@ -184,6 +205,16 @@ class TimelineGraphView(QWidget):
         self._spans.append((start_s, end_s, label))
         self._extend_range(start_s)
         self._extend_range(end_s)
+        self.update()
+
+    def append_state_change(self, name: str, rel_s: float, value: bool) -> None:
+        """Record a boolean signal transition (e.g. motor/lamp on-off) at
+        ``rel_s``. Unrecognized ``name``s are ignored - ``_STATE_NAMES`` is
+        the fixed set of rows this widget knows how to draw."""
+        if name not in self._states:
+            return
+        self._states[name].append((rel_s, value))
+        self._extend_range(rel_s)
         self.update()
 
     def _extend_range(self, t: float) -> None:
@@ -221,6 +252,22 @@ class TimelineGraphView(QWidget):
         span = self._t_view_max - self._t_view_min
         return self._t_view_min + (x / max(width, 1)) * span
 
+    def _lane_height(self) -> float:
+        """Lane row height, stretched to fill whatever vertical space this
+        widget is actually given (e.g. by a QSplitter) instead of leaving
+        blank space below a fixed-size block of rows - never smaller than
+        ``_LANE_H`` even in a cramped view."""
+        fixed = _TOP_MARGIN + _AXIS_H + _SPAN_H + _STATE_H * len(_STATE_NAMES) + 10
+        available = max(self.height() - fixed, _LANE_H * len(LANES))
+        return available / len(LANES)
+
+    def total_duration_s(self) -> float | None:
+        """Full recorded span (last event minus first) - independent of
+        the current zoom/pan, unlike ``_t_view_min``/``_t_view_max``."""
+        if self._t_data_min is None or self._t_data_max is None:
+            return None
+        return self._t_data_max - self._t_data_min
+
     # -- painting ------------------------------------------------------------
 
     def paintEvent(self, event) -> None:
@@ -233,8 +280,13 @@ class TimelineGraphView(QWidget):
         span = max(self._t_view_max - self._t_view_min, 1e-9)
         pixel_s = span / max(width, 1)
 
-        # phase/button markers: vertical dashed lines + rotated label
+        # phase/button markers: vertical dashed lines + rotated label.
+        # Labels are skipped (tick line stays) when they'd overlap the
+        # previous one - a rotated label's own bounding box is awkward to
+        # get exactly right, so horizontalAdvance is used as a conservative
+        # stand-in for "would this collide," not a precise layout.
         painter.setFont(QFont("", 8))
+        last_label_x: float | None = None
         for rel_s, label in self._markers:
             if not (self._t_view_min <= rel_s <= self._t_view_max):
                 continue
@@ -243,11 +295,16 @@ class TimelineGraphView(QWidget):
             pen.setStyle(Qt.PenStyle.DashLine)
             painter.setPen(pen)
             painter.drawLine(QPointF(x, _TOP_MARGIN), QPointF(x, height))
+            shown = label[:40]
+            text_w = painter.fontMetrics().horizontalAdvance(shown)
+            if last_label_x is not None and x < last_label_x + text_w * 0.7:
+                continue
+            last_label_x = x
             painter.save()
             painter.translate(x + 2, _TOP_MARGIN - 6)
             painter.rotate(-30)
             painter.setPen(QColor("#555555"))
-            painter.drawText(0, 0, label[:40])
+            painter.drawText(0, 0, shown)
             painter.restore()
 
         # axis
@@ -279,21 +336,42 @@ class TimelineGraphView(QWidget):
                 painter.setPen(_SPAN_COLOR)
                 painter.drawText(QPointF(x1 + 3, span_y0 + _SPAN_H - 4), label[:60])
 
-        # lanes
-        lane_y0 = _TOP_MARGIN + _AXIS_H + _SPAN_H
-        for li, lane in enumerate(LANES):
-            y = lane_y0 + li * _LANE_H
+        # states: on/off bars (Motor, Lamp) between spans and lanes
+        state_y0 = _TOP_MARGIN + _AXIS_H + _SPAN_H
+        painter.setFont(QFont("", 7))
+        for si, name in enumerate(_STATE_NAMES):
+            y = state_y0 + si * _STATE_H
             painter.setPen(QColor("#eeeeee"))
             painter.drawLine(0, y, width, y)
             painter.setPen(QColor("#999999"))
-            painter.drawText(4, y + _LANE_H - 6, lane)
+            painter.drawText(4, y + _STATE_H - 3, name)
+            changes = sorted(self._states.get(name, []), key=lambda c: c[0])
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(_STATE_COLOR)
+            for (t0, val), (t1, _next_val) in zip(changes, changes[1:] + [(self._t_view_max, None)]):
+                if not val or t1 < self._t_view_min or t0 > self._t_view_max:
+                    continue
+                x1 = self._x_for_t(max(t0, self._t_view_min), width)
+                x2 = self._x_for_t(min(t1, self._t_view_max), width)
+                painter.drawRect(QRectF(x1, y + 2, max(x2 - x1, 1.0), _STATE_H - 4))
+
+        # lanes
+        lane_y0 = state_y0 + _STATE_H * len(_STATE_NAMES)
+        lane_h = self._lane_height()
+        for li, lane in enumerate(LANES):
+            y = lane_y0 + li * lane_h
+            painter.setPen(QColor("#eeeeee"))
+            painter.drawLine(0, int(y), width, int(y))
+            painter.setPen(QColor("#999999"))
+            painter.drawText(4, int(y + lane_h - 6), lane)
 
             visible = [(t, i) for t, i in self._points[lane] if self._t_view_min <= t <= self._t_view_max]
             color = LANE_COLORS[lane]
             for cluster in cluster_points(visible, pixel_s):
                 x = self._x_for_t(cluster.t_center, width)
-                cy = y + _LANE_H / 2
-                r = 3.0 if cluster.count == 1 else min(3.0 + cluster.count**0.5, 10.0)
+                cy = y + lane_h / 2
+                r_max = max(3.0, lane_h / 2 - 2.0)
+                r = min(3.0, r_max) if cluster.count == 1 else min(3.0 + cluster.count**0.5, r_max)
                 painter.setBrush(color)
                 painter.setPen(Qt.PenStyle.NoPen)
                 painter.drawEllipse(QPointF(x, cy), r, r)
@@ -348,8 +426,8 @@ class TimelineGraphView(QWidget):
         self._drag_last_x = None
 
     def _index_near(self, x: float, y: float) -> int | None:
-        lane_y0 = _TOP_MARGIN + _AXIS_H
-        lane_idx = int((y - lane_y0) // _LANE_H)
+        lane_y0 = _TOP_MARGIN + _AXIS_H + _SPAN_H + _STATE_H * len(_STATE_NAMES)
+        lane_idx = int((y - lane_y0) // self._lane_height())
         if not (0 <= lane_idx < len(LANES)):
             return None
         lane = LANES[lane_idx]

--- a/tools/scanlab/forensic_values_panel.py
+++ b/tools/scanlab/forensic_values_panel.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Known/Unknown values side panel for the Forensic tab's Timeline view.
+
+Shows the register/table values collected for the selected run without
+requiring the user to scrub the timeline to find them - "Known" lists
+distinct milestone-derived values (slope table per feed, LPERIOD,
+EXPOSURE, pixel clock); "Unknown" lists register addresses touched this
+run that ``explain_register()`` has nothing to say about, so unexplained
+traffic is visible rather than silently dropped.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from PyQt6.QtWidgets import QGroupBox, QListWidget, QListWidgetItem, QVBoxLayout, QWidget
+
+from tools.scanlab.forensic_timecode import format_timecode
+
+
+class ValuesPanel(QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(4, 4, 4, 4)
+
+        known_box = QGroupBox("Known values")
+        known_layout = QVBoxLayout(known_box)
+        self.known_list = QListWidget()
+        known_layout.addWidget(self.known_list)
+        layout.addWidget(known_box, 1)
+
+        unknown_box = QGroupBox("Unknown registers (no catalog entry)")
+        unknown_layout = QVBoxLayout(unknown_box)
+        self.unknown_list = QListWidget()
+        unknown_layout.addWidget(self.unknown_list)
+        layout.addWidget(unknown_box, 1)
+
+    def clear(self) -> None:
+        self.known_list.clear()
+        self.unknown_list.clear()
+
+    def set_data(self, known: list[dict[str, Any]], unknown: list[dict[str, Any]]) -> None:
+        self.clear()
+        for entry in known:
+            timecode = format_timecode(entry.get("rel_s"))
+            item = QListWidgetItem(f"[{timecode}] {entry['label']}")
+            item.setToolTip(entry["label"])
+            self.known_list.addItem(item)
+        if not known:
+            self.known_list.addItem(QListWidgetItem("(no known values found for this run)"))
+
+        for entry in unknown:
+            timecode = format_timecode(entry.get("rel_s"))
+            item = QListWidgetItem(f"[{timecode}] {entry['addr']} = {entry['value']}")
+            self.unknown_list.addItem(item)
+        if not unknown:
+            self.unknown_list.addItem(QListWidgetItem("(nothing unexplained - or no run loaded)"))


### PR DESCRIPTION
## Summary
- Identifies which motor slope table (FAST/SLOW/CUSTOM) was uploaded for each positioning feed, from the raw AHB upload payload.
- Adds feed-timing (motor-enabled duration), LPERIOD, EXPOSURE, and pixel-clock milestones to the Forensic tab.
- New duration-bracket span rendering on the timeline widget, plus a motor/lamp on-off state band.
- New "Known/Unknown values" side panel and a "Positioning & timing" section in the AI bug report export.

## Test plan
- [x] Full suite: 327 passed, 1 skipped
- [x] `ruff check`: clean
- [x] Manually verified slope-table classification against 3 known runs: shipped default -> SLOW, a forced-FAST run -> FAST, a custom blended ramp -> CUSTOM