### PR TITLE
feat(scanlab): --crop, --multi-exposure, --save-tiff-dir for the headless CLI

### DIFF
--- a/tools/scanlab/cli.py
+++ b/tools/scanlab/cli.py
@@ -125,19 +125,36 @@ def cmd_scan(args: argparse.Namespace) -> int:
         print(json.dumps({"outcome": "error", "notes": str(exc), "run_dir": str(out_dir)}, indent=2))
         return 1
 
+    crop_norm = None
+    if args.crop:
+        parts = [float(v) for v in args.crop.split(",")]
+        if len(parts) != 4:
+            raise SystemExit("--crop expects 'x0,y0,x1,y1'")
+        crop_norm = tuple(parts)
+
+    if args.multi_exposure and args.kind != "scan":
+        raise SystemExit("--multi-exposure requires --kind scan")
+
     try:
         dpi = args.dpi or prescan_resolution(target.model)
-        kw = lab_scan_kwargs(target.model, dpi=dpi, kind=args.kind, crop_norm=None)
+        kw = lab_scan_kwargs(target.model, dpi=dpi, kind=args.kind, crop_norm=crop_norm)
         run.mark_phase(f"CLI: {args.kind} started", {"dpi": dpi, "mock": target.mock, "model": target.model.model})
         image = scanner.scan(
             mode="color",
             apply_calib=args.apply_calib,
             gl128_prime=args.gl128_prime,
+            multi_exposure=args.multi_exposure,
             **kw,
         )
         image_info = {"shape": list(image.rgb.shape), "dpi": image.dpi}
         run.mark_phase(f"CLI: {args.kind} received", image_info)
         outcome = "success"
+        if args.save_tiff_dir:
+            out = Path(args.save_tiff_dir)
+            out.mkdir(parents=True, exist_ok=True)
+            tiff_path = out / f"{args.name}.tiff"
+            image.save_tiff(tiff_path)
+            image_info["tiff_path"] = str(tiff_path)
     except Exception as exc:  # noqa: BLE001
         notes = f"{type(exc).__name__}: {exc}"
         if args.traceback:
@@ -273,6 +290,21 @@ def main(argv: list[str]) -> int:
     )
     p_scan.add_argument("--ai-report", action="store_true", help="also write ai_report.md into the run directory")
     p_scan.add_argument("--traceback", action="store_true", help="include a Python traceback in notes on failure")
+    p_scan.add_argument(
+        "--crop",
+        default=None,
+        help="normalized crop 'x0,y0,x1,y1' (0..1), scan kind only",
+    )
+    p_scan.add_argument(
+        "--multi-exposure",
+        action="store_true",
+        help="2-bracket multi-exposure color scan (scan kind only)",
+    )
+    p_scan.add_argument(
+        "--save-tiff-dir",
+        default=None,
+        help="write the resulting image as a 16-bit TIFF into this directory (human review only, not stored in the run dir)",
+    )
     p_scan.set_defaults(func=cmd_scan)
 
     sub.add_parser("list-runs", help="list recorded runs (RUNS_ROOT) as JSON").set_defaults(func=cmd_list_runs)

--- a/tools/scanlab/cli.py
+++ b/tools/scanlab/cli.py
@@ -19,12 +19,21 @@ checkouts/branches sharing a runs directory, e.g. via a directory
 junction, to compare a PR's behavior against main) can be diffed without
 opening the GUI at all.
 
+``scan``'s ``--crop``/``--multi-exposure`` (``--kind scan`` only) and
+``--save-tiff-dir`` cover the rest of CONTRIBUTING.md's hardware sign-off
+checklist (a crop, ME) and let a human visually confirm output without
+opening the GUI.
+
 Usage:
     python -m tools.scanlab.cli scan --model "OpticFilm 8100 (V2)" --mock \
         --kind prescan --dpi 1200 --name ci-smoke
 
     python -m tools.scanlab.cli scan --model "OpticFilm 8100 (V2)" --real \
         --kind scan --dpi 1800 --ai-report
+
+    python -m tools.scanlab.cli scan --model "OpticFilm 8100 (V2)" --real \
+        --kind scan --dpi 7200 --crop 0.25,0.25,0.75,0.75 --multi-exposure \
+        --save-tiff-dir ./review
 
     python -m tools.scanlab.cli list-models
     python -m tools.scanlab.cli list-runs
@@ -127,6 +136,8 @@ def cmd_scan(args: argparse.Namespace) -> int:
 
     crop_norm = None
     if args.crop:
+        if args.kind != "scan":
+            raise SystemExit("--crop requires --kind scan")
         parts = [float(v) for v in args.crop.split(",")]
         if len(parts) != 4:
             raise SystemExit("--crop expects 'x0,y0,x1,y1'")


### PR DESCRIPTION
## Summary

The headless `tools/scanlab/cli.py scan` command couldn't exercise a cropped
scan, a multi-exposure pass, or save a viewable image — needed these while
running real-hardware sign-off (PR #58's slope-table validation, per
`CONTRIBUTING.md`'s hardware checklist: park, full-frame at several dpi, a
crop, ME) and wanted to visually confirm scan output without opening the
Scan Lab GUI each time.

## Changes

- `--crop x0,y0,x1,y1`: normalized crop, `scan` kind only.
- `--multi-exposure`: 2-bracket multi-exposure color scan, `scan` kind only
  (guarded, same as `--crop`).
- `--save-tiff-dir DIR`: writes the resulting image as a 16-bit TIFF for
  human review; not stored in the forensic run dir.

No changes to scan/session/protocol code — this only wires existing
`lab_scan_kwargs`/`scanner.scan()` parameters through to the CLI's argparse
surface, the same way the GUI already exposes them.

## Test plan

- [x] `uv run pytest -q` — 326 passed, 1 skipped
- [x] `uv run ruff check .` — clean
- [x] Mock smoke test: `--crop` + `--multi-exposure` + `--save-tiff-dir`
      combined, produces a correctly-shaped cropped TIFF
- [x] Used for PR #58's real 8100 V2 hardware validation (park,
      1200/1800/7200dpi, a crop, ME) — all 6 runs succeeded