### PR TITLE
fix(gl128): weight ME multi-pass progress by exposure, not pass count

### DIFF
--- a/src/pyopticfilm/scan/session_gl128.py
+++ b/src/pyopticfilm/scan/session_gl128.py
@@ -70,6 +70,43 @@ def clamp_me_long_for_dpi(resolution: int, exp_long: int) -> int:
     return min(max(value, _ME_LONG_MIN), _ME_LONG_MAX)
 
 
+def me_early_pass_span(*, n_early: int, exp_short: int, exp_long: int, multi_exposure: bool) -> float:
+    """Fraction of a multi-pass scan's progress bar spent on the early (short/IR) passes.
+
+    REG_LPERIOD is fixed by dpi alone; REG_EXPOSURE is set per pass, so the ME
+    long pass needs several line periods per output line and reads out
+    proportionally slower than the short/IR passes. Splitting the bar evenly
+    by pass count made it crawl through the long pass, so early passes are
+    weighted by exposure instead — using ``exp_long`` as the only estimate
+    available before the adaptive pass selects the real one.
+    """
+    if not multi_exposure:
+        return 1.0
+    early_weight = n_early * exp_short
+    return early_weight / (early_weight + exp_long)
+
+
+def me_pass_progress(
+    idx: int,
+    p: float,
+    *,
+    n_early: int,
+    early_span: float,
+    multi_exposure: bool,
+) -> float:
+    """Overall multi-pass fraction for pass ``idx`` at within-pass fraction ``p``.
+
+    The long pass (``idx == n_early``, only when ``multi_exposure``) claims
+    whatever bar space ``early_span`` left, proportionally to its own byte
+    progress — so an adaptive exposure wider than the estimate ``early_span``
+    was sized from can only slow the pass down, never walk progress backward.
+    """
+    if multi_exposure and idx == n_early:
+        return min(1.0, early_span + (1.0 - early_span) * p)
+    step = early_span / n_early
+    return min(1.0, idx * step + step * p)
+
+
 try:
     from pyopticfilm.asic.gl128 import MOTOR_GATED_HINT as _MOTOR_GATED_HINT
 except ImportError:  # pragma: no cover
@@ -397,6 +434,9 @@ class Gl128ScanSession(ScanSession):
         if infrared:
             early.append(("ir", "infrared", exp_short, False, False, short_manual))
         n_pass = len(early) + (1 if multi_exposure else 0)
+        early_span = me_early_pass_span(
+            n_early=len(early), exp_short=exp_short, exp_long=exp_long, multi_exposure=multi_exposure
+        )
 
         logger.info(
             "GL128 multi-pass %ddpi passes=%d me=%s ir=%s me_exposure_mode=%s",
@@ -429,7 +469,11 @@ class Gl128ScanSession(ScanSession):
 
             def _prog(p: float, _i: int = idx) -> None:
                 if progress is not None:
-                    progress(min(1.0, (_i + p) / n_pass))
+                    progress(
+                        me_pass_progress(
+                            _i, p, n_early=len(early), early_span=early_span, multi_exposure=multi_exposure
+                        )
+                    )
 
             calib = None
             if apply_calib and self.calibrator is not None:

--- a/tests/test_me.py
+++ b/tests/test_me.py
@@ -8,6 +8,40 @@ import numpy as np
 from pyopticfilm.device.model_8200i_se import MODEL_8200I_SE
 from pyopticfilm.pass_align import align_pass_to_reference
 from pyopticfilm.scan.exposure_merge import merge_exposures, merge_exposures_result
+from pyopticfilm.scan.session_gl128 import me_early_pass_span, me_pass_progress
+
+
+def test_me_early_pass_span_weights_by_exposure_not_pass_count():
+    """The short pass is ~1/4 of a default 3x-ratio ME scan's real duration, not 1/2."""
+    span = me_early_pass_span(n_early=1, exp_short=14000, exp_long=42000, multi_exposure=True)
+    assert span == 0.25
+
+
+def test_me_early_pass_span_non_me_falls_back_to_pass_count():
+    span = me_early_pass_span(n_early=2, exp_short=14000, exp_long=0, multi_exposure=False)
+    assert span == 1.0
+
+
+def test_me_pass_progress_never_regresses_across_long_pass_boundary():
+    """A wider adaptive exposure than the a-priori estimate must not walk progress backward."""
+    span = me_early_pass_span(n_early=1, exp_short=14000, exp_long=42000, multi_exposure=True)
+    seen = [
+        me_pass_progress(0, 0.5, n_early=1, early_span=span, multi_exposure=True),
+        me_pass_progress(0, 1.0, n_early=1, early_span=span, multi_exposure=True),
+        # The long pass proceeds independently of how much larger the real
+        # exposure (say 85000, not the 42000 default) turned out to be.
+        me_pass_progress(1, 0.0, n_early=1, early_span=span, multi_exposure=True),
+        me_pass_progress(1, 0.5, n_early=1, early_span=span, multi_exposure=True),
+        me_pass_progress(1, 1.0, n_early=1, early_span=span, multi_exposure=True),
+    ]
+    assert seen == sorted(seen)
+    assert seen[-1] == 1.0
+
+
+def test_me_pass_progress_matches_even_split_when_not_multi_exposure():
+    span = me_early_pass_span(n_early=2, exp_short=14000, exp_long=0, multi_exposure=False)
+    assert me_pass_progress(0, 0.5, n_early=2, early_span=span, multi_exposure=False) == 0.25
+    assert me_pass_progress(1, 0.5, n_early=2, early_span=span, multi_exposure=False) == 0.75
 
 
 def test_model_me_exposure_constants():


### PR DESCRIPTION
## Summary
- GL128 multi-exposure (ME) scan progress reported via `Scanner.scan(..., progress=...)` split the bar evenly across passes (`(idx + p) / n_pass` in `Gl128ScanSession._run_multi_pass`'s `_prog`), treating the short and long exposure passes as equal-duration.
- They are not: `REG_LPERIOD` is fixed by dpi alone (`model.line_period_for(dpi)`), but `REG_EXPOSURE` is set per pass. The long pass's exposure is 3x-6x the short pass's (default `exposure_short=14000` / `exposure_long=42000` on `MODEL_8200I_SE`, adaptively up to `me_hardware_max_exposure=85000`), so the ASIC needs proportionally more line periods per output line and reads out that much slower. In practice this reported ~50% right after the fast short pass, then crawled through the much slower long pass for most of the scan's real duration.
- Fixed by weighting the early (short/IR) passes' share of the bar by exposure instead of pass count — using the model's default `exposure_long` as the a-priori estimate, since the adaptive/fixed selection isn't made until after the short pass completes — then letting the long pass claim whatever bar space is left, proportional to its own byte progress. This means a wider adaptive selection than the default estimate can only slow the reported rate down, never walk progress backward.
- Extracted the weighting math into two pure, unit-tested functions: `me_early_pass_span()` and `me_pass_progress()`.
- Single-pass scans and IR-only (non-ME) multi-pass scans are unaffected — both passes there share the same exposure, so the even split was already correct. Confirmed by a downstream NegPy user: "Accurate on single-pass scan, only problem on Multi-Exposure."

## Test plan
- [x] `uv run pytest tests/test_me.py -q` (23 passed, includes 4 new tests for the weighting/progress functions)
- [x] `uv run pytest tests/ -q` (327 passed, 4 skipped)
- [x] `uv run ruff check` on the changed files