### PR TITLE
fix(8100v2): give V2 its own ladder_lincnt_by_dpi + full capture re-validation of both GL128 models

### DIFF
--- a/src/pyopticfilm/device/gl128_common.py
+++ b/src/pyopticfilm/device/gl128_common.py
@@ -260,6 +260,7 @@ GL128_DIVERGENT_FIELDS: frozenset[str] = frozenset(
         "lperiod_by_dpi",
         "max_image_lincnt_by_feed2",
         "ladder_feed2_steps",
+        "ladder_lincnt_by_dpi",
     }
 )
 
@@ -331,7 +332,6 @@ GL128_SHARED_FIELDS: frozenset[str] = frozenset(
         "feed_to_scan_bottom_steps",
         "max_feed_steps",
         "scan_window_end_steps",
-        "ladder_lincnt_by_dpi",
         "motor_profile",
         "init_regs",
         "sensor_custom_regs",
@@ -442,9 +442,6 @@ class Gl128Common:
     feed_to_scan_bottom_steps: int = 20232
     max_feed_steps: int = 28292
     scan_window_end_steps: int = 27636
-    ladder_lincnt_by_dpi: Mapping[int, int] = field(
-        default_factory=lambda: dict(LADDER_LINCNT_BY_DPI)
-    )
     motor_profile: MotorProfile = DEFAULT_GL845_MOTOR
     init_regs: Mapping[int, int] = field(default_factory=lambda: dict(INIT_REGS))
     sensor_custom_regs: Mapping[int, int] = field(default_factory=lambda: dict(SCAN_REGS))
@@ -463,6 +460,7 @@ class Gl128Common:
         lperiod_by_dpi: Mapping[int, int]
         max_image_lincnt_by_feed2: Mapping[int, int]
         ladder_feed2_steps: int
+        ladder_lincnt_by_dpi: Mapping[int, int]
 
     @property
     def max_area_mm(self) -> tuple[float, float]:

--- a/src/pyopticfilm/device/model_8100_v2.py
+++ b/src/pyopticfilm/device/model_8100_v2.py
@@ -50,7 +50,19 @@ all derived from USB captures of the V2 Windows driver (capture session Aug
     feed2 = 13 128 (top of TA window) for all scan types, matching
     ``feed_to_scan_steps``.
     *Capture evidence*: ``04_color_7200.pcapng`` frame 2999, same as
-    ``feed_to_scan_steps``.
+    ``feed_to_scan_steps``. Confirmed directly (not just extrapolated) by the
+    ``06_ppi_ladder.pcapng`` reference capture in ``pyopticfilm_captures``,
+    which reproduces feed2 = 13 128 at every rung of the DPI ladder.
+
+**ladder_lincnt_by_dpi**
+    V2's ladder crop starts 432 steps earlier than the SE's (13 128 vs
+    13 560), so it needs a taller image LINCNT at every PPI to cover the same
+    physical window. ``06_ppi_ladder.pcapng`` gives a directly measured image
+    LINCNT for each rung (150/300/600 dpi all floor to the same ASIC
+    programming and share one value); the 7200 dpi entry is carried over from
+    ``04_color_7200.pcapng`` (matches ``max_image_lincnt_by_feed2``). Every
+    entry is the SE's session-13 value plus ``128 * asic_dpi / 600`` — the
+    proportional cost of the 432-step-longer crop.
 
 Unlike the 8200i SE, the 8100 V2 has no infrared channel or iSRD support.
 Multi-exposure colour scanning remains supported.
@@ -61,7 +73,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 
-from pyopticfilm.device.gl128_common import LPERIOD_BY_DPI, Gl128Common
+from pyopticfilm.device.gl128_common import LADDER_LINCNT_BY_DPI, LPERIOD_BY_DPI, Gl128Common
 
 # V2 7200 dpi LPERIOD observed in all three scan phases (dark/white shading and
 # image pass): 16 035.  All other DPI entries are carried over from the shared
@@ -71,12 +83,32 @@ _LPERIOD_BY_DPI_V2: dict[int, int] = {
     7200: 16035,
 }
 
+# V2's ladder crop (feed2=13128) starts 432 steps earlier than the SE's
+# (feed2=13560), so it needs a taller image LINCNT at every PPI: the SE's
+# session-13 value plus 128 * asic_dpi / 600. 150/300/600 dpi all floor to the
+# same 600 dpi ASIC programming and share one measured value.
+# Source: 06_ppi_ladder.pcapng (150-3600 dpi) + 04_color_7200.pcapng (7200 dpi).
+_LADDER_LINCNT_BY_DPI_V2: dict[int, int] = {
+    150: 2420,
+    300: 2420,
+    600: 2420,
+    720: 2904,
+    900: 3628,
+    1200: 4836,
+    1440: 5804,
+    1800: 7252,
+    2400: 9668,
+    3600: 14500,
+    7200: 29012,
+}
+assert set(_LADDER_LINCNT_BY_DPI_V2) == set(LADDER_LINCNT_BY_DPI)
+
 
 @dataclass(frozen=True)
 class Model8100V2(Gl128Common):
     """OpticFilm 8100 V2 — GL128 sibling of the 8200i SE without IR.
 
-    See module docstring for the five capture-derived overrides.
+    See module docstring for the six capture-derived overrides.
     """
 
     name: str = "plustek-opticfilm-8100-v2"
@@ -100,6 +132,12 @@ class Model8100V2(Gl128Common):
 
     # V2 uses feed2=13128 for all scan types (top of TA window), not SE's 13560.
     ladder_feed2_steps: int = 13128
+
+    # V2 ladder crop needs a taller LINCNT than the SE's at every PPI (see
+    # module docstring). Source: 06_ppi_ladder.pcapng + 04_color_7200.pcapng.
+    ladder_lincnt_by_dpi: Mapping[int, int] = field(
+        default_factory=lambda: dict(_LADDER_LINCNT_BY_DPI_V2)
+    )
 
     def shading_strip_clocks(self, resolution: int, *, dvdset: bool) -> tuple[int, int, int]:
         """Return ``(dummy, clk_a, clk_b)`` for a shading strip.

--- a/src/pyopticfilm/device/model_8200i_se.py
+++ b/src/pyopticfilm/device/model_8200i_se.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 
-from pyopticfilm.device.gl128_common import LPERIOD_BY_DPI, Gl128Common
+from pyopticfilm.device.gl128_common import LADDER_LINCNT_BY_DPI, LPERIOD_BY_DPI, Gl128Common
 
 
 @dataclass(frozen=True)
@@ -76,6 +76,14 @@ class Model8200iSE(Gl128Common):
 
     #: Session 13 PPI-ladder second feed (crop origin; PPI-independent).
     ladder_feed2_steps: int = 13560
+
+    #: Session 13 PPI-ladder image LINCNT per SilverFast PPI, at this model's
+    #: own ``ladder_feed2_steps`` (13560). V2's ladder crop starts 432 steps
+    #: earlier (feed2=13128), so it needs a taller crop and its own table —
+    #: see :data:`~pyopticfilm.device.model_8100_v2._LADDER_LINCNT_BY_DPI_V2`.
+    ladder_lincnt_by_dpi: Mapping[int, int] = field(
+        default_factory=lambda: dict(LADDER_LINCNT_BY_DPI)
+    )
 
 
 MODEL_8200I_SE = Model8200iSE()

--- a/src/pyopticfilm/scan/bringup.py
+++ b/src/pyopticfilm/scan/bringup.py
@@ -100,7 +100,7 @@ def preview_safe_scan_area(
 
 
 def ladder_scan_area(model: Any, dpi: int) -> tuple[Area, dict[str, Any]]:
-    """Session-13 PPI-ladder crop (feed2=13560, capture LINCNT for ``dpi``)."""
+    """Session-13 PPI-ladder crop (model's own ``ladder_feed2_steps`` / capture LINCNT for ``dpi``)."""
     feed2 = int(getattr(model, "ladder_feed2_steps", 13560))
     lincnt_fn = getattr(model, "ladder_lincnt_for", None)
     if callable(lincnt_fn):

--- a/tests/test_gl128_siblings.py
+++ b/tests/test_gl128_siblings.py
@@ -68,6 +68,32 @@ def test_divergent_fields_match_capture_catalog():
         20232: 3700,
     }
     assert dict(MODEL_8100_V2.max_image_lincnt_by_feed2) == {13128: 29012}
+    assert dict(MODEL_8200I_SE.ladder_lincnt_by_dpi) == {
+        150: 2292,
+        300: 2292,
+        600: 2292,
+        720: 2748,
+        900: 3436,
+        1200: 4580,
+        1440: 5496,
+        1800: 6868,
+        2400: 9156,
+        3600: 13732,
+        7200: 27476,
+    }
+    assert dict(MODEL_8100_V2.ladder_lincnt_by_dpi) == {
+        150: 2420,
+        300: 2420,
+        600: 2420,
+        720: 2904,
+        900: 3628,
+        1200: 4836,
+        1440: 5804,
+        1800: 7252,
+        2400: 9668,
+        3600: 14500,
+        7200: 29012,
+    }
 
 
 def test_every_public_field_is_catalogued():


### PR DESCRIPTION
## Summary

While using the new `8100-v2/` reference captures in `pyopticfilm_captures` to sanity-check the 8100 V2 model, I found one place where V2 was silently inheriting an 8200i SE value it shouldn't have (`ladder_lincnt_by_dpi`), fixed it with real V2 hardware measurements, and then used the exercise as a reason to check everything else on both models against their full capture datasets.

### The fix: 8100 V2's `ladder_lincnt_by_dpi`

`ladder_lincnt_by_dpi` was declared once on `Gl128Common` and inherited by both leaf models — the only GL128 table that wasn't in `GL128_DIVERGENT_FIELDS` despite depending on a value (`ladder_feed2_steps`) that *is* divergent. The V2's PPI-ladder crop starts at `feed2=13128`, 432 steps earlier than the SE's `feed2=13560`, so the same physical ladder crop needs a taller `LINCNT` on the V2 at every PPI — it was using the SE's numbers instead.

Only `bringup.ladder_scan_area()` reads this table (bring-up/regression crop reproduction, not live scan geometry), so `scan()`/`home()`/`park()` were never affected on real hardware.

Fixed it the way `CONTRIBUTING.md` says to: gave `Model8100V2` its own table (measured from `06_ppi_ladder.pcapng` + `04_color_7200.pcapng`), moved the field from `GL128_SHARED_FIELDS` to `GL128_DIVERGENT_FIELDS`, declared it explicitly on both leaves, extended `test_gl128_siblings.py`'s catalog test with both models' exact values. Every rung's V2 value is the SE's value plus a constant `128 * asic_dpi / 600` — the proportional travel cost of the 432-step-shorter crop:

| dpi | SE value | V2 value | diff | diff ÷ (asic_dpi/600) |
|---:|---:|---:|---:|---:|
| 150/300/600 | 2292 | 2420 | 128 | 128 |
| 720 | 2748 | 2904 | 156 | 130 |
| 900 | 3436 | 3628 | 192 | 128 |
| 1200 | 4580 | 4836 | 256 | 128 |
| 1440 | 5496 | 5804 | 308 | 128.3 |
| 1800 | 6868 | 7252 | 384 | 128 |
| 2400 | 9156 | 9668 | 512 | 128 |
| 3600 | 13732 | 14500 | 768 | 128 |
| 7200 | 27476 | 29012 | 1536 | 128 |

That the fitted constant lands the same way at every rung (rather than needing a different fudge factor per DPI) is independent evidence that both tables, and the fix, are correct.

## What's changing

- `src/pyopticfilm/device/gl128_common.py` — `ladder_lincnt_by_dpi` moved from `GL128_SHARED_FIELDS` to `GL128_DIVERGENT_FIELDS`; dropped as a real field on `Gl128Common` (now `TYPE_CHECKING`-only, matching the other four divergent knobs).
- `src/pyopticfilm/device/model_8100_v2.py` — new `_LADDER_LINCNT_BY_DPI_V2` table (measured from `06_ppi_ladder.pcapng` + `04_color_7200.pcapng`), declared as V2's own `ladder_lincnt_by_dpi`; docstring documents it as the 6th capture-derived divergence.
- `src/pyopticfilm/device/model_8200i_se.py` — now declares `ladder_lincnt_by_dpi` explicitly with its existing session-13 values. **No value changes for the SE** — this is a mechanical move from inherited-shared to explicitly-declared, so the sibling-diff catalog covers it correctly.
- `src/pyopticfilm/scan/bringup.py` — fixed a docstring comment on `ladder_scan_area()` that hardcoded "feed2=13560" as if it applied to both models.
- `tests/test_gl128_siblings.py` — added explicit value assertions for both models' `ladder_lincnt_by_dpi` tables to the capture catalog test.

## What's not changing

- Every other V2 field: `feed_to_scan_steps`, `lperiod_by_dpi[7200]`, the white-strip `shading_strip_clocks` dummy, `max_image_lincnt_by_feed2`, `ladder_feed2_steps` — re-confirmed byte-for-byte against the entire `8100-v2/` dataset (7 captures), including two that had no part in deriving them originally: `07_multi_exposure.pcapng`'s 4 sub-scans and `02_cold_boot_open.pcapng`'s 116-register boot blast. All exact, no changes needed.
- Anything on the 8200i SE side beyond the mechanical field-declaration move above. I ran the same register-level check against all 30 captures in `8200i-se/` — the 11-file PPI ladder, both Y-crop sessions, the IR pass, the 24-bit/48-bit pair, back-to-back, three midtravel-cancel captures, and the 6-file multi-exposure set. Every shared and divergent field the SE declares (`INIT_REGS`, `MEMORY_LAYOUT_REGS`, `lperiod_by_dpi`, `ladder_lincnt_by_dpi`, `max_image_lincnt_by_feed2`, IR AFE fallback constants, ME exposure constants) checks out exactly against the capture data. No SE behavior changes in this PR.

## Test plan
- [x] `pytest tests/test_gl128_siblings.py tests/test_multi_model.py tests/model_lock/ tests/test_pipeline_patterns.py -q` — 98 passed
- [x] `pytest -q` (full suite) — 323 passed, 4 skipped (pre-existing hardware-only skips)
- [x] `ruff check` on all changed files — clean
- [x] Every value above cross-checked against a fresh register-level decode of the cited capture via `tools/capture_ledger.py`
