### PR TITLE
fix(8200i-se): use true scan-window top (13128) as feed_to_scan_steps

### DIFF
--- a/src/pyopticfilm/device/model_8200i_se.py
+++ b/src/pyopticfilm/device/model_8200i_se.py
@@ -55,8 +55,12 @@ class Model8200iSE(Gl128Common):
     usb_product_id: int = 0x1825
     supports_infrared: bool = True
 
-    #: Default full-frame colour (sessions 04–06). V2 uses 13128 (TA window top).
-    feed_to_scan_steps: int = 13704
+    #: Default full-frame colour. Sessions 03/08/09a measured the true scan-window
+    #: top at 13128 (matches feed_to_scan_top_steps and the V2's value for this
+    #: purpose); 13704 from session 04 is only "full-ish" (see
+    #: captures/8200i-se/09_y_crop_pair/NOTES.md) and overruns the window at high
+    #: DPI (see #67).
+    feed_to_scan_steps: int = 13128
 
     #: SilverFast 9 PPI ladder (session 13). V2 overrides 7200 dpi only.
     lperiod_by_dpi: Mapping[int, int] = field(

--- a/tests/model_lock/opticfilm_8200i_se/test_bringup.py
+++ b/tests/model_lock/opticfilm_8200i_se/test_bringup.py
@@ -31,13 +31,13 @@ def test_bringup_preview_safe_passes_motor_gate_at_1200():
     assert geometry.lincnt_register <= max_lc
 
 
-def test_default_full_frame_without_bringup_trips_gate_at_1200():
-    """Regression: area=None + feed2=13704 cannot fit full TA height."""
+def test_default_full_frame_without_bringup_fits_gate_at_1200():
+    """Regression for #67: area=None + feed2=13128 (true TA window top) fits."""
     geometry = compute_geometry(1200, model=MODEL_8200I_SE, area=None)
     feed2 = MODEL_8200I_SE.feed_to_scan_steps_for_area(None)
-    assert feed2 == 13704
+    assert feed2 == 13128
     max_lc = MODEL_8200I_SE.max_lincnt_for(feed2, 1200)
-    assert geometry.lincnt_register > max_lc
+    assert geometry.lincnt_register <= max_lc
 
 
 def test_full_window_1800_stays_2592_even():

--- a/tests/test_gl128_siblings.py
+++ b/tests/test_gl128_siblings.py
@@ -55,7 +55,7 @@ def test_divergent_fields_match_capture_catalog():
     assert MODEL_8100_V2.usb_product_id == 0x1824
     assert MODEL_8200I_SE.supports_infrared is True
     assert MODEL_8100_V2.supports_infrared is False
-    assert MODEL_8200I_SE.feed_to_scan_steps == 13704
+    assert MODEL_8200I_SE.feed_to_scan_steps == 13128
     assert MODEL_8100_V2.feed_to_scan_steps == 13128
     assert MODEL_8200I_SE.ladder_feed2_steps == 13560
     assert MODEL_8100_V2.ladder_feed2_steps == 13128

--- a/tests/test_multi_model.py
+++ b/tests/test_multi_model.py
@@ -151,9 +151,9 @@ def test_8100_v2_capture_derived_constants():
     from pyopticfilm.device.model_8100_v2 import MODEL_8100_V2
     from pyopticfilm.device.model_8200i_se import MODEL_8200I_SE
 
-    # feed_to_scan_steps differs from SE default (13704)
+    # feed_to_scan_steps matches SE (both use the TA window top, see #67)
     assert MODEL_8100_V2.feed_to_scan_steps == 13128
-    assert MODEL_8200I_SE.feed_to_scan_steps == 13704
+    assert MODEL_8200I_SE.feed_to_scan_steps == 13128
 
     # lperiod at 7200 dpi differs from SE (15963)
     assert MODEL_8100_V2.lperiod_by_dpi[7200] == 16035


### PR DESCRIPTION
## Summary
- `Model8200iSE.feed_to_scan_steps` was `13704` (session 04), which the capture notes (`captures/8200i-se/09_y_crop_pair/NOTES.md`) call only "full-ish", not the true window top.
- Sessions 03/08 and 09a independently measured the real top of the scan window at `13128` — the value already used for `feed_to_scan_top_steps` and for the 8100 V2's full-frame default (same mechanical window).
- `13704` overruns the window at higher DPI, aborting full-frame scans with a `LINCNT` `ScanError`.
- Updated the model-lock/catalog tests that asserted the old `13704` default so they reflect the corrected geometry.

Fixes #67. Hardware-validated by @harlock974 on an OpticFilm 8200i SE.

## Test plan
- [x] `pytest` — 318 passed, 1 skipped
- [x] Confirmed by reporter on real hardware (see issue #67 comments)