### PR TITLE
fix(calib): tolerate corrupt calib cache, make save atomic

### DIFF
--- a/src/pyopticfilm/scan/calibrate.py
+++ b/src/pyopticfilm/scan/calibrate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import base64
 import json
+import os
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -142,7 +143,9 @@ class CalibCache:
         try:
             raw = json.loads(self.path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
-            raise CalibrationError(f"Failed to read calib cache: {exc}") from exc
+            logger.warning("Ignoring unreadable calib cache at %s: %s", self.path, exc)
+            self.entries = []
+            return False
         if raw.get("ident") != CACHE_IDENT or int(raw.get("version", 0)) != CACHE_VERSION:
             logger.warning("Ignoring incompatible calib cache at %s", self.path)
             self.entries = []
@@ -158,7 +161,9 @@ class CalibCache:
             "version": CACHE_VERSION,
             "entries": [e.to_dict() for e in self.entries],
         }
-        self.path.write_text(json.dumps(payload), encoding="utf-8")
+        tmp_path = self.path.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(payload), encoding="utf-8")
+        os.replace(tmp_path, self.path)
         logger.info("Wrote calib cache %s (%d entries)", self.path, len(self.entries))
 
     def find(

--- a/tests/test_calib_cache_corruption.py
+++ b/tests/test_calib_cache_corruption.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""CalibCache must tolerate a corrupt/truncated on-disk file and save atomically.
+
+A corrupt cache previously raised CalibrationError straight out of
+Calibrator.__init__, bricking scanner construction until the file was deleted
+by hand. It should be treated the same as "no cache" (logged, ignored).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pyopticfilm.device.model_8200i import MODEL_8200I
+from pyopticfilm.scan.calibrate import CalibCache, Calibrator
+
+
+def test_load_with_corrupt_json_treated_as_missing(tmp_path: Path):
+    path = tmp_path / "calib.json"
+    path.write_text("{not valid json", encoding="utf-8")
+
+    cache = CalibCache(path)
+    assert cache.load() is False
+    assert cache.entries == []
+
+
+def test_calibrator_construction_survives_corrupt_cache(tmp_path: Path):
+    path = tmp_path / "calib.json"
+    path.write_text("{not valid json", encoding="utf-8")
+
+    # Must not raise CalibrationError.
+    cal = Calibrator(asic=None, cache_path=path, model=MODEL_8200I)
+    assert cal.cache.entries == []
+
+
+def test_save_is_atomic_no_leftover_tmp_file(tmp_path: Path):
+    path = tmp_path / "calib.json"
+    cache = CalibCache(path)
+    cache.save()
+
+    assert path.exists()
+    assert not path.with_suffix(".tmp").exists()
+
+
+def test_save_survives_crash_mid_write_leaving_old_file_intact(tmp_path: Path):
+    path = tmp_path / "calib.json"
+    cache = CalibCache(path)
+    cache.save()
+    good_contents = path.read_text(encoding="utf-8")
+
+    # Simulate a crash mid-write: a leftover partial tmp file must not be
+    # mistaken for the real cache, and the previously-saved file must be
+    # untouched.
+    tmp_path_file = path.with_suffix(".tmp")
+    tmp_path_file.write_text("{truncat", encoding="utf-8")
+
+    assert path.read_text(encoding="utf-8") == good_contents
+    cache2 = CalibCache(path)
+    assert cache2.load() is True


### PR DESCRIPTION
## Summary
- `CalibCache.load()` raised `CalibrationError` on any corrupt/truncated JSON, and that raise happened unguarded inside `Calibrator.__init__` — a corrupt `calib.json` bricked scanner construction until the file was deleted by hand. Now logs and treats it the same as a missing/version-mismatched cache.
- `CalibCache.save()` now writes to a `.tmp` file and `os.replace()`s it into place, so a crash mid-write can no longer leave a truncated cache for the next `load()` to choke on.
