### PR TITLE
fix(gl845): clamp AFE dichotomy search width to 8-bit FE registers

### DIFF
--- a/src/pyopticfilm/asic/gl845.py
+++ b/src/pyopticfilm/asic/gl845.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable
+from dataclasses import replace
 
 from pyopticfilm.asic.registers import Gl845Registers
 from pyopticfilm.asic.status import ScannerStatus
@@ -32,6 +33,10 @@ HOME_POLL_S = 0.1
 FE_BUSY_TIMEOUT_S = 5.0
 # Large feed length used while seeking home (genesys reverse-home uses ~40000).
 HOME_FEED_STEPS = 40000
+#: GL845 FE gain/offset registers (0x02-0x07) are single-byte; a wider
+#: AfeSearchConfig (e.g. GL128's default 0x1FF) would converge on a code that
+#: silently truncates on write (apply_afe_frontend masks & 0xFF).
+FE_REGISTER_MAX = 0xFF
 
 
 class Gl845:
@@ -257,6 +262,12 @@ class Gl845:
             return seed
 
         cfg = config or AfeSearchConfig()
+        if cfg.gain_max > FE_REGISTER_MAX or cfg.offset_max > FE_REGISTER_MAX:
+            cfg = replace(
+                cfg,
+                gain_max=min(cfg.gain_max, FE_REGISTER_MAX),
+                offset_max=min(cfg.offset_max, FE_REGISTER_MAX),
+            )
 
         def _measure(fe: AfeFrontend) -> tuple[float, float, float]:
             self.apply_afe_frontend(fe, method=method, resolution=resolution)

--- a/tests/test_gl845_afe_gain_width.py
+++ b/tests/test_gl845_afe_gain_width.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""GL845 FE registers are 8-bit; AfeSearchConfig.gain_max defaults to 0x1FF
+(the GL128 width). force_dichotomy=True on GL845 must not search codes that
+get silently truncated by the ``& 0xFF`` register write.
+"""
+
+from __future__ import annotations
+
+from pyopticfilm.asic.gl845 import Gl845
+from pyopticfilm.device.model_8200i import MODEL_8200I
+from pyopticfilm.scan.calib_gl128 import AfeFrontend
+from pyopticfilm.usb.fake import FakeUsbTransport
+from pyopticfilm.usb.protocol import GenesysUsbProtocol
+
+
+def _gl845() -> Gl845:
+    usb = FakeUsbTransport()
+    usb.registers[0x04] = 0x22
+    proto = GenesysUsbProtocol(usb)
+    asic = Gl845(proto, MODEL_8200I)
+    asic._initialized = True
+    asic._reg_cache = {0x04: 0x22}
+    return asic
+
+
+def test_force_dichotomy_default_config_does_not_exceed_8bit_gain():
+    """With no config override, a bright strip must not push the search past 0xFF."""
+    asic = _gl845()
+
+    def measure(fe: AfeFrontend) -> tuple[float, float, float]:
+        # Always-dim strip (target is 0xD000): dichotomy keeps climbing gain
+        # toward code_max (0x1FF by default) looking for more signal.
+        return (100.0, 100.0, 100.0)
+
+    result = asic.search_afe(method="transparency", measure=measure, force_dichotomy=True)
+
+    assert all(0 <= g <= 0xFF for g in result.gains), result.gains
+    assert all(0 <= o <= 0xFF for o in result.offsets), result.offsets
+    # What the search converged on must match what was actually written to
+    # the 8-bit FE registers -- no silent truncation on apply.
+    assert asic.last_afe_gains == result.gains
+    assert asic.last_afe_offsets == result.offsets


### PR DESCRIPTION
## Summary
- `AfeSearchConfig.gain_max`/`offset_max` default to GL128's 0x1FF register width. `Gl845.search_afe(force_dichotomy=True)` with no explicit config passed that straight into `run_afe_dichotomy`, letting the search converge on codes above `0xFF`.
- `Gl845.apply_afe_frontend`/`apply_frontend_for_scan` write the GL845's single-byte FE gain/offset registers with `& 0xFF`, so a code like `0x12A` would silently get programmed as `0x2A` -- the search result and what's actually on the wire diverge.
- Latent today: the default (non-forced) ADI FESET path skips dichotomy entirely, so no current caller hits this. It's a real trap for `force_dichotomy=True`, a documented parameter on `search_afe`.
- Fix clamps `cfg.gain_max`/`offset_max` to `FE_REGISTER_MAX` (0xFF) inside `search_afe` before searching, since the register width is a GL845 hardware fact, not something callers should need to know.

Found during AI-assisted review of the AFE calibration path; verified against the actual register-write code (not taken on faith) before fixing.

## Test plan
- [x] Added `tests/test_gl845_afe_gain_width.py` -- a dim strip with default `AfeSearchConfig()` previously converged on gain `510` (would truncate to `254` on write); now stays within `0xFF` and matches what's actually written
- [x] Existing `tests/test_gl845_afe.py` (ADI FESET skip, explicit-config dichotomy convergence) still pass
- [x] `uv run pytest -q` -- 316 passed, 4 skipped
- [x] `uv run ruff check` -- clean

https://claude.ai/code/session_01J7La1WzqLEPG981QWPAFmn