### PR TITLE
fix(calibrate): probe search_afe signature instead of catching TypeError

### DIFF
--- a/src/pyopticfilm/scan/calibrate.py
+++ b/src/pyopticfilm/scan/calibrate.py
@@ -4,9 +4,10 @@
 from __future__ import annotations
 
 import base64
+import inspect
 import json
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -47,6 +48,31 @@ def colour_shading_failure_message(reason: str) -> str:
 
 def default_cache_path() -> Path:
     return Path.home() / ".cache" / "pyopticfilm" / "calib_v2.json"
+
+
+def call_search_afe(
+    search: Callable[..., object],
+    *,
+    method: str,
+    resolution: int,
+    measure: Callable[[object], tuple[float, float, float]] | None,
+) -> object:
+    """Call an ASIC's ``search_afe`` with whichever kwargs its signature takes.
+
+    GL845's ``search_afe`` takes ``method``/``resolution``/``measure``; GL128's
+    is self-contained (``config``/``method`` only) and does its own capture.
+    Dispatch on the signature rather than calling the GL845 shape and catching
+    ``TypeError`` — a bare except there would also swallow a genuine
+    ``TypeError`` raised from inside ``measure()`` or the dichotomy internals
+    and misattribute it to the GL128 signature mismatch.
+    """
+    params = inspect.signature(search).parameters
+    if "measure" not in params:
+        return search(method=method)
+    kwargs: dict[str, object] = {"method": method, "measure": measure}
+    if "resolution" in params:
+        kwargs["resolution"] = resolution
+    return search(**kwargs)
 
 
 @dataclass
@@ -654,10 +680,7 @@ class Calibrator:
                         float(avg[:, 2].mean()),
                     )
 
-            try:
-                search(method=method, resolution=resolution, measure=measure)
-            except TypeError:
-                search(method=method)
+            call_search_afe(search, method=method, resolution=resolution, measure=measure)
 
         def _safe_home() -> None:
             """GL845 repark; SE has no reverse-home — noop only when already home."""

--- a/tests/test_calibrator_search_afe_dispatch.py
+++ b/tests/test_calibrator_search_afe_dispatch.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Calibrator.run's search_afe dispatch: signature probe, not except TypeError.
+
+Regression for a shim that caught bare TypeError to fall back from GL845's
+search_afe(method, resolution, measure) shape to GL128's search_afe(config,
+method) shape. That also swallowed a genuine TypeError raised inside
+measure() or the dichotomy internals, silently degrading calibration to
+table defaults instead of surfacing the bug.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyopticfilm.scan.calibrate import call_search_afe
+
+
+def test_dispatches_gl845_shape_with_method_resolution_measure():
+    calls: list[dict] = []
+
+    def search_afe(*, method=None, resolution=None, measure=None):
+        calls.append({"method": method, "resolution": resolution, "measure": measure})
+
+    def measure(fe):
+        return (0.0, 0.0, 0.0)
+
+    call_search_afe(search_afe, method="transparency", resolution=1800, measure=measure)
+
+    assert calls == [{"method": "transparency", "resolution": 1800, "measure": measure}]
+
+
+def test_dispatches_gl128_shape_with_method_only():
+    calls: list[dict] = []
+
+    def search_afe(*, config=None, method=None):
+        calls.append({"config": config, "method": method})
+
+    call_search_afe(search_afe, method="transparency", resolution=1800, measure=lambda fe: (0.0, 0.0, 0.0))
+
+    assert calls == [{"config": None, "method": "transparency"}]
+
+
+def test_typeerror_inside_measure_propagates_instead_of_falling_back():
+    """A real bug in measure() must not be mistaken for a signature mismatch."""
+    fallback_calls: list[str] = []
+
+    def search_afe(*, method=None, resolution=None, measure=None):
+        measure(object())  # exercises the caller-supplied measure
+
+    def broken_measure(fe):
+        fallback_calls.append("called")
+        raise TypeError("int() argument must be a string, not 'float32'")
+
+    with pytest.raises(TypeError, match="float32"):
+        call_search_afe(search_afe, method="transparency", resolution=1800, measure=broken_measure)
+
+    assert fallback_calls == ["called"]


### PR DESCRIPTION
## Summary
- `Calibrator.run` called `search(method=, resolution=, measure=)` and caught `TypeError` to fall back to `search(method=)` for GL128's narrower `search_afe(config, method)` signature.
- That bare `except TypeError` also caught a genuine `TypeError` raised from *inside* `measure()` or the dichotomy internals during a GL845 run (e.g. a bad value passed where a float32 mean was expected) — silently degrading calibration to table defaults instead of surfacing the bug, with no error and one fewer log line than the real failure deserved.
- Extracted the dispatch into `call_search_afe()`, which inspects the target's signature once (`"measure" in inspect.signature(search).parameters`) instead of shape-testing by exception. GL845 gets `method`/`resolution`/`measure`; GL128 gets `method` only, exactly as before — this is a pure refactor of the fallback mechanism, not a behavior change for either ASIC's happy path.
